### PR TITLE
Refactor backend & add OpenRouter + LLM token streaming

### DIFF
--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -1,28 +1,29 @@
 """
 Guitar Tutor LangGraph Agent.
-Provides music theory and guitar-related answers using a two-node graph:
+Provides music theory and guitar-related answers using a three-node graph:
 1. prepare_question - normalizes and validates the user's question
-2. generate_answer - generates a structured answer with chord/scale recommendations
+2. clarify_input - handles interrupt/resume for clarifying questions
+3. generate_answer - generates a structured answer with chord/scale recommendations
 """
-from langgraph.checkpoint.memory import MemorySaver
 
-import os
 import logging
-from typing import List, Optional, TypedDict
-from pydantic import BaseModel, Field
-from langgraph.graph import StateGraph, START, END, MessagesState
+import os
+from typing import Generator, List, Optional, TypedDict
+
+from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
-from dotenv import load_dotenv
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
+from pydantic import Field
 
-# Load environment variables
 load_dotenv()
 
 logger = logging.getLogger(__name__)
 
 
-# --- Pydantic Schemas for structured LLM output ---
+# --- Structured output schemas ---
 
 class PreppedQuestionSchema(TypedDict):
     """Schema for the prepare_question node output."""
@@ -50,7 +51,7 @@ class OverallState(MessagesState):
     out_of_scope: bool = False
 
 
-# --- Prompt Templates ---
+# --- Prompt templates ---
 
 PREP_QUESTION_INSTRUCTIONS = """You are the Guitar Tutor question normalizer. You will ONLY prepare a single, concise MUSIC THEORY / GUITAR question for the NEXT node to answer — do NOT answer the question yourself.
 
@@ -97,65 +98,71 @@ Tone & pedagogy:
 Question: {user_question}
 """
 
+# Node names for status tracking
+_NODE_FIELDS = {
+    "question_for_llm": "prepare_question",
+    "answer": "generate_answer",
+    "clarifying_question": "prepare_question",
+}
+
 
 class GuitarTutorAgent:
     """Guitar Tutor Agent using LangGraph."""
-    
+
     def __init__(self, model_name: str = "gpt-4o-mini", temperature: float = 0):
-        """Initialize the agent with the specified model."""
         self.memory = MemorySaver()
 
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise ValueError("OPENAI_API_KEY environment variable is not set")
-        
+
         self.llm = ChatOpenAI(model=model_name, temperature=temperature)
         self.graph = self._build_graph()
 
+    # --- Graph construction ---
+
     def _build_graph(self) -> StateGraph:
-        """Build and compile the LangGraph state machine."""
         builder = StateGraph(OverallState)
-        
+
         builder.add_node("prepare_question", self._prepare_question)
         builder.add_node("clarify_input", self._clarify_input)
         builder.add_node("generate_answer", self._generate_answer)
-        
-        builder.add_edge(START, "prepare_question")
-        builder.add_edge("prepare_question", "clarify_input")  # Check if clarification needed
-        # clarify_input routes itself using Command
-        builder.add_edge("generate_answer", END)
-        
-        return builder.compile(checkpointer=self.memory)
-    
-    def _prepare_question(self, state: dict) -> dict:
-        """Prepare and normalize the user's question."""
 
+        builder.add_edge(START, "prepare_question")
+        builder.add_edge("prepare_question", "clarify_input")
+        builder.add_edge("generate_answer", END)
+
+        return builder.compile(checkpointer=self.memory)
+
+    # --- Graph nodes ---
+
+    def _prepare_question(self, state: dict) -> dict:
         structured_llm = self.llm.with_structured_output(PreppedQuestionSchema)
-        
-        messages = state.get('messages', [])
-        # Only use the last 4 messages for context (last 3 messages + current)
+
+        messages = state.get("messages", [])
         recent_messages = messages[-4:] if len(messages) > 4 else messages
-        previous_context = "\n".join([msg.content for msg in recent_messages[:-1]]) if len(recent_messages) > 1 else "None"
+        previous_context = (
+            "\n".join([msg.content for msg in recent_messages[:-1]])
+            if len(recent_messages) > 1
+            else "None"
+        )
         last_question_text = messages[-1].content if messages else ""
 
         system_message = SystemMessage(
             content=PREP_QUESTION_INSTRUCTIONS.format(
                 previous_context=previous_context,
-                user_question=last_question_text
+                user_question=last_question_text,
             )
         )
-        
-        # Only pass system message - context is already embedded in it
+
         result = structured_llm.invoke([system_message])
-        
-        # Normalize result
-        if isinstance(result, dict):
-            q = result
-        else:
-            q = result.model_dump() if hasattr(result, 'model_dump') else result.dict()
-        
+
+        q = result if isinstance(result, dict) else (
+            result.model_dump() if hasattr(result, "model_dump") else result.dict()
+        )
+
         logger.info(f"Prepared question: {q}")
-        
+
         return {
             "question_for_llm": q.get("question_for_llm"),
             "clarifying_question": q.get("clarifying_question"),
@@ -163,36 +170,29 @@ class GuitarTutorAgent:
         }
 
     def _clarify_input(self, state: dict) -> Command:
-        """Handle clarifying questions if needed."""
         clarifying_question = state.get("clarifying_question")
-        
-        # If there's no clarifying question, skip this node
+
         if not clarifying_question:
             return Command(goto="generate_answer")
-        
-        # Interrupt() must come first - get human's response
+
         human_input = interrupt({
             "clarifying_question": clarifying_question,
-            "action": "Please answer this question to continue"
+            "action": "Please answer this question to continue",
         })
-        
-        # Append human's response to messages and clear the clarifying question
+
         return Command(
             update={
                 "messages": [HumanMessage(content=human_input.get("response", ""))],
-                "clarifying_question": None
+                "clarifying_question": None,
             },
-            goto="prepare_question"  # Re-run to now prepare the actual question
+            goto="prepare_question",
         )
 
     def _generate_answer(self, state: dict) -> dict:
-        """Generate a structured answer based on the prepared question."""
-        messages = state.get('messages', [])
         question_for_llm = state.get("question_for_llm")
         clarifying_question = state.get("clarifying_question")
         out_of_scope = state.get("out_of_scope", False)
-        
-        # Handle out of scope questions
+
         if out_of_scope:
             refusal_msg = "I only help with guitar & music theory — please ask about chords, scales, fretboard shapes, voicings, or music theory concepts."
             return {
@@ -203,8 +203,7 @@ class GuitarTutorAgent:
                 "visualizations": False,
                 "out_of_scope": True,
             }
-        
-        # Handle clarifying questions
+
         if clarifying_question and not question_for_llm:
             return {
                 "messages": [AIMessage(content=clarifying_question)],
@@ -214,29 +213,26 @@ class GuitarTutorAgent:
                 "visualizations": False,
                 "out_of_scope": False,
             }
-        
-        # Generate answer for valid questions
+
         structured_llm = self.llm.with_structured_output(AnswerRequestSchema)
-        
+        messages = state.get("messages", [])
+
         question_text = question_for_llm if question_for_llm else (
             messages[-1].content if messages else ""
         )
-        
+
         system_message = SystemMessage(
             content=QUESTION_INSTRUCTIONS.format(user_question=question_text)
         )
-        
-        human_msg = HumanMessage(content=question_text)
-        result = structured_llm.invoke([system_message, human_msg])
-        
-        # Normalize result
-        if isinstance(result, dict):
-            q = result
-        else:
-            q = result.model_dump() if hasattr(result, 'model_dump') else result.dict()
-        
+
+        result = structured_llm.invoke([system_message, HumanMessage(content=question_text)])
+
+        q = result if isinstance(result, dict) else (
+            result.model_dump() if hasattr(result, "model_dump") else result.dict()
+        )
+
         answer_text = q.get("answer", "")
-        
+
         return {
             "messages": [AIMessage(content=answer_text)],
             "answer": answer_text,
@@ -245,59 +241,65 @@ class GuitarTutorAgent:
             "visualizations": q.get("visualizations", False),
             "out_of_scope": False,
         }
-    
-    def chat(
-        self,
-        message: str,
-        conversation_history: List[dict] = None,
-        thread_id: Optional[str] = "1",
-    ) -> dict:
-        """
-        Process a user message and return the agent's response.
-        
-        Args:
-            message: The user's message
-            conversation_history: Optional list of previous messages
-            thread_id: Thread ID for conversation tracking
-        
-        Returns:
-            dict with keys: answer, scale, chord_choices, visualizations, out_of_scope, 
-            interrupted (bool), interrupt_data (if interrupted)
-        """
-        config = {"configurable": {"thread_id": thread_id}}
-        
-        # Build messages list from conversation history
+
+    # --- Shared helpers ---
+
+    @staticmethod
+    def _build_messages(conversation_history: List[dict], message: str) -> list:
         messages = []
-        
         if conversation_history:
             for msg in conversation_history:
                 if msg.get("role") == "user":
                     messages.append(HumanMessage(content=msg["content"]))
                 elif msg.get("role") == "assistant":
                     messages.append(AIMessage(content=msg["content"]))
-        
-        # Add the current message
         messages.append(HumanMessage(content=message))
-        
-        # Stream the graph to handle interrupts
-        output = None
-        for event in self.graph.stream({"messages": messages}, config=config, stream_mode="values"):
-            output = event
-        
-        # Check if interrupted
+        return messages
+
+    def _check_for_interrupt(self, config: dict) -> Optional[dict]:
         state_snapshot = self.graph.get_state(config)
-        is_interrupted = False
-        interrupt_data = None
-        
         if state_snapshot.tasks:
             for task in state_snapshot.tasks:
                 if task.interrupts:
-                    is_interrupted = True
-                    interrupt_data = task.interrupts[0].value
-                    break
-        
-        # If interrupted, return interrupt info
-        if is_interrupted:
+                    return task.interrupts[0].value
+        return None
+
+    @staticmethod
+    def _extract_result(output: dict) -> dict:
+        return {
+            "interrupted": False,
+            "answer": output.get("answer", ""),
+            "scale": output.get("scale"),
+            "chord_choices": output.get("chord_choices", []),
+            "visualizations": output.get("visualizations", False),
+            "out_of_scope": output.get("out_of_scope", False),
+        }
+
+    @staticmethod
+    def _identify_node(event: dict) -> str:
+        """Identify which node produced this state update."""
+        for field, node in _NODE_FIELDS.items():
+            if event.get(field):
+                return node
+        return "processing"
+
+    # --- Public API: synchronous ---
+
+    def chat(
+        self,
+        message: str,
+        conversation_history: List[dict] = None,
+        thread_id: Optional[str] = "1",
+    ) -> dict:
+        config = {"configurable": {"thread_id": thread_id}}
+        messages = self._build_messages(conversation_history or [], message)
+
+        output = None
+        for event in self.graph.stream({"messages": messages}, config=config, stream_mode="values"):
+            output = event
+
+        interrupt_data = self._check_for_interrupt(config)
+        if interrupt_data:
             return {
                 "interrupted": True,
                 "interrupt_data": interrupt_data,
@@ -307,85 +309,78 @@ class GuitarTutorAgent:
                 "visualizations": False,
                 "out_of_scope": False,
             }
-        
-        # Convert messages to serializable format for debug output
-        debug_messages = []
-        for msg in output.get("messages", []):
-            debug_messages.append({
-                "type": type(msg).__name__,
-                "content": msg.content,
-            })
-        
-        return {
-            "interrupted": False,
-            "answer": output.get("answer", ""),
-            "scale": output.get("scale"),
-            "chord_choices": output.get("chord_choices", []),
-            "visualizations": output.get("visualizations", False),
-            "out_of_scope": output.get("out_of_scope", False),
-            "debug_state": {
-                "messages": debug_messages,
-                "question_for_llm": output.get("question_for_llm"),
-                "clarifying_question": output.get("clarifying_question"),
-                "answer": output.get("answer"),
-                "scale": output.get("scale"),
-                "chord_choices": output.get("chord_choices", []),
-                "visualizations": output.get("visualizations", False),
-                "out_of_scope": output.get("out_of_scope", False),
-            },
-        }
+
+        return self._extract_result(output)
 
     def resume_chat(
         self,
         human_response: str,
         thread_id: Optional[str] = "1",
     ) -> dict:
-        """Resume from an interrupt with human input."""
         config = {"configurable": {"thread_id": thread_id}}
-        
-        # Resume with the human response
+
         output = None
         for event in self.graph.stream(
             Command(resume={"response": human_response}),
             config=config,
-            stream_mode="values"
+            stream_mode="values",
         ):
             output = event
-        
-        # Convert messages to serializable format
-        debug_messages = []
-        for msg in output.get("messages", []):
-            debug_messages.append({
-                "type": type(msg).__name__,
-                "content": msg.content,
-            })
-        
-        return {
-            "interrupted": False,
-            "answer": output.get("answer", ""),
-            "scale": output.get("scale"),
-            "chord_choices": output.get("chord_choices", []),
-            "visualizations": output.get("visualizations", False),
-            "out_of_scope": output.get("out_of_scope", False),
-            "debug_state": {
-                "messages": debug_messages,
-                "question_for_llm": output.get("question_for_llm"),
-                "clarifying_question": output.get("clarifying_question"),
-            },
-        }
+
+        return self._extract_result(output)
 
     def check_interrupt(self, thread_id: str = "1") -> Optional[dict]:
-        """Check if there's an active interrupt for the given thread."""
         config = {"configurable": {"thread_id": thread_id}}
-        state_snapshot = self.graph.get_state(config)
-        
-        # Check if there are pending tasks with interrupts
-        if state_snapshot.tasks:
-            for task in state_snapshot.tasks:
-                if task.interrupts:
-                    return task.interrupts[0].value  # Return the interrupt data
-        
-        return None
+        return self._check_for_interrupt(config)
+
+    # --- Public API: streaming (SSE) ---
+
+    def stream_chat(
+        self,
+        message: str,
+        conversation_history: List[dict] = None,
+        thread_id: Optional[str] = "1",
+    ) -> Generator[dict, None, None]:
+        """Stream chat processing as SSE event dicts."""
+        config = {"configurable": {"thread_id": thread_id}}
+        messages = self._build_messages(conversation_history or [], message)
+
+        last_output = None
+        for event in self.graph.stream({"messages": messages}, config=config, stream_mode="values"):
+            node = self._identify_node(event)
+            logger.debug(f"Stream event from node: {node}")
+            yield {"event": "status", "data": {"node": node}}
+            last_output = event
+
+        interrupt_data = self._check_for_interrupt(config)
+        if interrupt_data:
+            yield {"event": "interrupt", "data": interrupt_data}
+            return
+
+        if last_output:
+            yield {"event": "answer", "data": self._extract_result(last_output)}
+
+    def stream_resume(
+        self,
+        human_response: str,
+        thread_id: Optional[str] = "1",
+    ) -> Generator[dict, None, None]:
+        """Stream resume processing as SSE event dicts."""
+        config = {"configurable": {"thread_id": thread_id}}
+
+        last_output = None
+        for event in self.graph.stream(
+            Command(resume={"response": human_response}),
+            config=config,
+            stream_mode="values",
+        ):
+            node = self._identify_node(event)
+            logger.debug(f"Stream event from node: {node}")
+            yield {"event": "status", "data": {"node": node}}
+            last_output = event
+
+        if last_output:
+            yield {"event": "answer", "data": self._extract_result(last_output)}
 
 
 # Singleton instance (lazy initialization)

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -109,14 +109,20 @@ _NODE_FIELDS = {
 class GuitarTutorAgent:
     """Guitar Tutor Agent using LangGraph."""
 
-    def __init__(self, model_name: str = "gpt-4o-mini", temperature: float = 0):
+    def __init__(self, model_name: str = "gpt-4o-mini", temperature: float = 0,
+                 base_url: str | None = None, api_key: str | None = None):
         self.memory = MemorySaver()
+        self.model_name = model_name
 
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
+        resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not resolved_key:
             raise ValueError("OPENAI_API_KEY environment variable is not set")
 
-        self.llm = ChatOpenAI(model=model_name, temperature=temperature)
+        llm_kwargs: dict = {"model": model_name, "temperature": temperature, "api_key": resolved_key}
+        if base_url:
+            llm_kwargs["base_url"] = base_url
+
+        self.llm = ChatOpenAI(**llm_kwargs)
         self.graph = self._build_graph()
 
     # --- Graph construction ---
@@ -389,7 +395,14 @@ _agent_instance: Optional[GuitarTutorAgent] = None
 
 def get_agent() -> GuitarTutorAgent:
     """Get or create the singleton agent instance."""
+    from app.config import get_settings
+
     global _agent_instance
     if _agent_instance is None:
-        _agent_instance = GuitarTutorAgent()
+        settings = get_settings()
+        _agent_instance = GuitarTutorAgent(
+            model_name=settings.model_name,
+            base_url=settings.llm_base_url,
+            api_key=settings.llm_api_key,
+        )
     return _agent_instance

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -32,9 +32,8 @@ class PreppedQuestionSchema(TypedDict):
     clarifying_question: Optional[str] = Field(None, description="A clarifying question if needed")
 
 
-class AnswerRequestSchema(TypedDict):
-    """Schema for the generate_answer node output."""
-    answer: str = Field(..., description="The answer text to return to the user")
+class AnswerMetadataSchema(TypedDict):
+    """Schema for answer metadata extraction (scale, chords, visualizations)."""
     scale: str = Field(..., description="A single recommended scale name relevant to the user question")
     chord_choices: List[str] = Field(..., description="List of chord names recommended")
     visualizations: bool = Field(False, description="Whether visualizations are needed")
@@ -76,26 +75,29 @@ Output requirements (JSON ONLY): produce exactly one of these three JSON shapes 
 - Do NOT include voicings, diagrams, notes, or additional metadata.
 """
 
-QUESTION_INSTRUCTIONS = """You are the Guitar Tutor LLM node. Your role is to interpret a user's question and return a focused, helpful, music-theory / guitar-oriented answer.
+ANSWER_TEXT_INSTRUCTIONS = """You are the Guitar Tutor. Answer the user's guitar/music theory question.
 
-Hard constraints (must be strictly followed):
+Hard constraints:
 - ONLY answer music theory or guitar-related questions.
-- When recommending chord(s) or scale(s), LIMIT output to chord or scale NAMES ONLY (e.g., 'C major', 'A minor').
-- Always provide a single relevant `scale` string in every response.
-- When listing chord options, use the `chord_choices` array with chord names only.
-- Keep output concise and structured.
-
-Behavior & output format:
-- Decide whether output can be presented visually (chord progression, chords, or scale). If yes, set `visualizations` to true.
-- Always include a short, clear `answer` field (1-3 concise paragraphs).
-- Always include the `scale` field with a single recommended scale name.
-- Include chord recommendations in `chord_choices` array.
+- Mention relevant chords and scales by name (e.g., "C major", "A minor pentatonic").
+- Keep output concise: 1-3 paragraphs.
 
 Tone & pedagogy:
 - Be friendly, clear, and pedagogical. Explain WHY choices work.
-- Use short examples in the `answer` field.
+- Use short examples where helpful.
 
 Question: {user_question}
+"""
+
+ANSWER_METADATA_INSTRUCTIONS = """Given this guitar/music question and answer, extract structured metadata. Return ONLY the requested fields.
+
+Question: {user_question}
+Answer: {answer}
+
+Extract:
+- scale: the single most relevant scale name (e.g., "A minor pentatonic")
+- chord_choices: list of chord names mentioned or recommended (e.g., ["C", "Am", "F", "G"])
+- visualizations: true if the answer involves chords, scales, or progressions that can be shown on a fretboard
 """
 
 # Node names for status tracking
@@ -220,31 +222,36 @@ class GuitarTutorAgent:
                 "out_of_scope": False,
             }
 
-        structured_llm = self.llm.with_structured_output(AnswerRequestSchema)
         messages = state.get("messages", [])
-
         question_text = question_for_llm if question_for_llm else (
             messages[-1].content if messages else ""
         )
 
-        system_message = SystemMessage(
-            content=QUESTION_INSTRUCTIONS.format(user_question=question_text)
+        # Call 1: Generate answer text (regular LLM — streamed via stream_mode="messages")
+        text_system = SystemMessage(
+            content=ANSWER_TEXT_INSTRUCTIONS.format(user_question=question_text)
         )
+        response = self.llm.invoke([text_system, HumanMessage(content=question_text)])
+        answer_text = response.content
 
-        result = structured_llm.invoke([system_message, HumanMessage(content=question_text)])
-
-        q = result if isinstance(result, dict) else (
+        # Call 2: Extract metadata (structured output — quick, not streamed)
+        metadata_llm = self.llm.with_structured_output(AnswerMetadataSchema)
+        metadata_system = SystemMessage(
+            content=ANSWER_METADATA_INSTRUCTIONS.format(
+                user_question=question_text, answer=answer_text
+            )
+        )
+        result = metadata_llm.invoke([metadata_system])
+        meta = result if isinstance(result, dict) else (
             result.model_dump() if hasattr(result, "model_dump") else result.dict()
         )
-
-        answer_text = q.get("answer", "")
 
         return {
             "messages": [AIMessage(content=answer_text)],
             "answer": answer_text,
-            "scale": q.get("scale"),
-            "chord_choices": q.get("chord_choices", []),
-            "visualizations": q.get("visualizations", False),
+            "scale": meta.get("scale"),
+            "chord_choices": meta.get("chord_choices", []),
+            "visualizations": meta.get("visualizations", False),
             "out_of_scope": False,
         }
 
@@ -341,22 +348,25 @@ class GuitarTutorAgent:
 
     # --- Public API: streaming (SSE) ---
 
-    def stream_chat(
-        self,
-        message: str,
-        conversation_history: List[dict] = None,
-        thread_id: Optional[str] = "1",
-    ) -> Generator[dict, None, None]:
-        """Stream chat processing as SSE event dicts."""
-        config = {"configurable": {"thread_id": thread_id}}
-        messages = self._build_messages(conversation_history or [], message)
-
+    def _iter_stream(self, graph_input, config) -> Generator[dict, None, None]:
+        """Shared streaming logic: yields status, token, interrupt, and answer events."""
         last_output = None
-        for event in self.graph.stream({"messages": messages}, config=config, stream_mode="values"):
-            node = self._identify_node(event)
-            logger.debug(f"Stream event from node: {node}")
-            yield {"event": "status", "data": {"node": node}}
-            last_output = event
+
+        for mode, event in self.graph.stream(
+            graph_input, config=config, stream_mode=["messages", "values"]
+        ):
+            if mode == "messages":
+                chunk, metadata = event
+                node = metadata.get("langgraph_node", "")
+                # Only yield text tokens from the answer text call, not structured output calls
+                has_content = chunk.content and not getattr(chunk, "tool_call_chunks", None)
+                if node == "generate_answer" and has_content:
+                    yield {"event": "token", "data": {"text": chunk.content}}
+            elif mode == "values":
+                node = self._identify_node(event)
+                logger.debug(f"Stream event from node: {node}")
+                yield {"event": "status", "data": {"node": node}}
+                last_output = event
 
         interrupt_data = self._check_for_interrupt(config)
         if interrupt_data:
@@ -366,6 +376,17 @@ class GuitarTutorAgent:
         if last_output:
             yield {"event": "answer", "data": self._extract_result(last_output)}
 
+    def stream_chat(
+        self,
+        message: str,
+        conversation_history: List[dict] = None,
+        thread_id: Optional[str] = "1",
+    ) -> Generator[dict, None, None]:
+        """Stream chat processing as SSE event dicts."""
+        config = {"configurable": {"thread_id": thread_id}}
+        messages = self._build_messages(conversation_history or [], message)
+        yield from self._iter_stream({"messages": messages}, config)
+
     def stream_resume(
         self,
         human_response: str,
@@ -373,20 +394,9 @@ class GuitarTutorAgent:
     ) -> Generator[dict, None, None]:
         """Stream resume processing as SSE event dicts."""
         config = {"configurable": {"thread_id": thread_id}}
-
-        last_output = None
-        for event in self.graph.stream(
-            Command(resume={"response": human_response}),
-            config=config,
-            stream_mode="values",
-        ):
-            node = self._identify_node(event)
-            logger.debug(f"Stream event from node: {node}")
-            yield {"event": "status", "data": {"node": node}}
-            last_output = event
-
-        if last_output:
-            yield {"event": "answer", "data": self._extract_result(last_output)}
+        yield from self._iter_stream(
+            Command(resume={"response": human_response}), config
+        )
 
 
 # Singleton instance (lazy initialization)
@@ -400,8 +410,12 @@ def get_agent() -> GuitarTutorAgent:
     global _agent_instance
     if _agent_instance is None:
         settings = get_settings()
+        logger.info(
+            f"Initializing agent: provider={settings.llm_provider}, "
+            f"model={settings.llm_model_name}, base_url={settings.llm_base_url}"
+        )
         _agent_instance = GuitarTutorAgent(
-            model_name=settings.model_name,
+            model_name=settings.llm_model_name,
             base_url=settings.llm_base_url,
             api_key=settings.llm_api_key,
         )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,8 +18,17 @@ class Settings(BaseSettings):
 
     allowed_origins: str = "http://localhost:5173,http://127.0.0.1:5173"
     openai_api_key: Optional[str] = None
+    openrouter_api_key: Optional[str] = None
+    llm_base_url: Optional[str] = None
     model_name: str = "gpt-4o-mini"
     log_level: str = "INFO"
+
+    @property
+    def llm_api_key(self) -> str | None:
+        """Use OpenRouter key when a custom base URL is set, otherwise OpenAI key."""
+        if self.llm_base_url:
+            return self.openrouter_api_key
+        return self.openai_api_key
 
     @property
     def origins_list(self) -> list[str]:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,83 @@
+"""
+Application configuration, CORS middleware, and logging setup.
+"""
+
+import logging
+import os
+import re
+from functools import lru_cache
+from typing import Optional
+
+from pydantic_settings import BaseSettings
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    allowed_origins: str = "http://localhost:5173,http://127.0.0.1:5173"
+    openai_api_key: Optional[str] = None
+    model_name: str = "gpt-4o-mini"
+    log_level: str = "INFO"
+
+    @property
+    def origins_list(self) -> list[str]:
+        return [o.strip() for o in self.allowed_origins.split(",") if o.strip()]
+
+    model_config = {"env_file": ".env"}
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+# --- CORS ---
+
+# Regex patterns for dynamic origins (Vercel preview deployments)
+ORIGIN_PATTERNS = [
+    re.compile(r"^https://guitar-tutor-.*\.vercel\.app$"),
+    re.compile(r"^https://.*-david-montes-de-ocas-projects\.vercel\.app$"),
+]
+
+
+def is_origin_allowed(origin: str) -> bool:
+    """Check if origin is in the allowed list or matches a dynamic pattern."""
+    if origin in get_settings().origins_list:
+        return True
+    return any(p.match(origin) for p in ORIGIN_PATTERNS)
+
+
+class DynamicCORSMiddleware(BaseHTTPMiddleware):
+    """CORS middleware that supports regex patterns for dynamic origins."""
+
+    async def dispatch(self, request: Request, call_next):
+        origin = request.headers.get("origin")
+
+        if request.method == "OPTIONS":
+            response = await call_next(request)
+            if origin and is_origin_allowed(origin):
+                response.headers["Access-Control-Allow-Origin"] = origin
+                response.headers["Access-Control-Allow-Credentials"] = "true"
+                response.headers["Access-Control-Allow-Methods"] = "*"
+                response.headers["Access-Control-Allow-Headers"] = "*"
+            return response
+
+        response = await call_next(request)
+
+        if origin and is_origin_allowed(origin):
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+
+        return response
+
+
+# --- Logging ---
+
+def setup_logging() -> None:
+    settings = get_settings()
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,35 +6,55 @@ import logging
 import os
 import re
 from functools import lru_cache
+from pathlib import Path
 from typing import Optional
 
 from pydantic_settings import BaseSettings
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
+# Resolve .env from project root (two levels up from this file: app/ -> backend/ -> root/)
+# Falls back to empty string if file doesn't exist (e.g., Docker where env vars come from compose)
+_candidate = Path(__file__).resolve().parents[2] / ".env"
+_ENV_FILE = str(_candidate) if _candidate.exists() else None
+
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
     allowed_origins: str = "http://localhost:5173,http://127.0.0.1:5173"
+    llm_provider: str = "openai"  # "openai" or "openrouter"
     openai_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None
-    llm_base_url: Optional[str] = None
-    model_name: str = "gpt-4o-mini"
+    model_name: Optional[str] = None
     log_level: str = "INFO"
+
+    _PROVIDER_DEFAULTS: dict = {
+        "openai": {"base_url": None, "default_model": "gpt-4o-mini"},
+        "openrouter": {"base_url": "https://openrouter.ai/api/v1", "default_model": "minimax/minimax-m2.5"},
+    }
 
     @property
     def llm_api_key(self) -> str | None:
-        """Use OpenRouter key when a custom base URL is set, otherwise OpenAI key."""
-        if self.llm_base_url:
+        if self.llm_provider == "openrouter":
             return self.openrouter_api_key
         return self.openai_api_key
+
+    @property
+    def llm_base_url(self) -> str | None:
+        return self._PROVIDER_DEFAULTS.get(self.llm_provider, {}).get("base_url")
+
+    @property
+    def llm_model_name(self) -> str:
+        if self.model_name:
+            return self.model_name
+        return self._PROVIDER_DEFAULTS.get(self.llm_provider, {}).get("default_model", "gpt-4o-mini")
 
     @property
     def origins_list(self) -> list[str]:
         return [o.strip() for o in self.allowed_origins.split(",") if o.strip()]
 
-    model_config = {"env_file": ".env"}
+    model_config = {"env_file": _ENV_FILE, "extra": "ignore"}
 
 
 @lru_cache

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -1,0 +1,38 @@
+"""
+Custom exceptions and global exception handlers.
+"""
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class AgentConfigError(Exception):
+    """Raised when the agent is not properly configured (e.g., missing API key)."""
+    pass
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(AgentConfigError)
+    async def agent_config_error_handler(request: Request, exc: AgentConfigError):
+        logger.error(f"Agent configuration error: {exc}")
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Agent not configured properly. Please check OPENAI_API_KEY."},
+        )
+
+    @app.exception_handler(ValueError)
+    async def value_error_handler(request: Request, exc: ValueError):
+        logger.warning(f"Bad request: {exc}")
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    @app.exception_handler(Exception)
+    async def generic_error_handler(request: Request, exc: Exception):
+        logger.exception(f"Unhandled error: {exc}")
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "An internal error occurred."},
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,11 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-import os
-import re
 
+from app.config import DynamicCORSMiddleware, get_settings, setup_logging
+from app.exceptions import register_exception_handlers
 from app.routers import fretboard, tunings, scales, chords, agent
+
+setup_logging()
 
 app = FastAPI(
     title="Guitar Tutor API",
@@ -13,69 +13,20 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# Configure CORS origins via environment variable so hosted frontends can be allowed.
-# Set ALLOWED_ORIGINS as a comma-separated list, e.g.:
-#   ALLOWED_ORIGINS=https://your-frontend.vercel.app,http://localhost:5173
-allowed_origins_env = os.getenv('ALLOWED_ORIGINS')
-if allowed_origins_env:
-    allowed_origins = [o.strip() for o in allowed_origins_env.split(',') if o.strip()]
-else:
-    # sensible default for local dev
-    allowed_origins = ["http://localhost:5173", "http://127.0.0.1:5173"]
+register_exception_handlers(app)
 
-# Regex patterns for dynamic origins (like Vercel preview deployments)
-# Matches: https://guitar-tutor-*.vercel.app and https://*-david-montes-de-ocas-projects.vercel.app
-origin_patterns = [
-    re.compile(r'^https://guitar-tutor-.*\.vercel\.app$'),
-    re.compile(r'^https://.*-david-montes-de-ocas-projects\.vercel\.app$'),
-]
-
-def is_origin_allowed(origin: str) -> bool:
-    """Check if origin is in allowed list or matches a pattern."""
-    if origin in allowed_origins:
-        return True
-    for pattern in origin_patterns:
-        if pattern.match(origin):
-            return True
-    return False
-
-class DynamicCORSMiddleware(BaseHTTPMiddleware):
-    """Custom CORS middleware that supports regex patterns for origins."""
-    
-    async def dispatch(self, request: Request, call_next):
-        origin = request.headers.get("origin")
-        
-        # Handle preflight requests
-        if request.method == "OPTIONS":
-            response = await call_next(request)
-            if origin and is_origin_allowed(origin):
-                response.headers["Access-Control-Allow-Origin"] = origin
-                response.headers["Access-Control-Allow-Credentials"] = "true"
-                response.headers["Access-Control-Allow-Methods"] = "*"
-                response.headers["Access-Control-Allow-Headers"] = "*"
-            return response
-        
-        response = await call_next(request)
-        
-        if origin and is_origin_allowed(origin):
-            response.headers["Access-Control-Allow-Origin"] = origin
-            response.headers["Access-Control-Allow-Credentials"] = "true"
-        
-        return response
-
-# Use custom CORS middleware for dynamic origin matching
+# CORS
+settings = get_settings()
 app.add_middleware(DynamicCORSMiddleware)
-
-# Also add standard CORS middleware for static origins (as fallback)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=allowed_origins,
+    allow_origins=settings.origins_list,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-# Include routers
+# Routers
 app.include_router(fretboard.router, prefix="/api", tags=["fretboard"])
 app.include_router(tunings.router, prefix="/api", tags=["tunings"])
 app.include_router(scales.router, prefix="/api", tags=["scales"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,2 @@
+from app.models.music import *  # noqa: F401,F403
+from app.models.agent import *  # noqa: F401,F403

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -1,0 +1,60 @@
+"""
+Pydantic schemas for agent chat endpoints.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class AgentMessage(BaseModel):
+    """A single message in a conversation."""
+    role: str  # "user" or "assistant"
+    content: str
+
+
+class AgentRequest(BaseModel):
+    """Request for /api/agent/chat endpoint."""
+    message: str
+    conversation_history: List[AgentMessage] = []
+    thread_id: Optional[str] = "default"
+
+
+class ChordApiRequest(BaseModel):
+    """Parsed chord API request info."""
+    root: str
+    quality: str
+    original_name: str
+    endpoint: str
+
+
+class ScaleApiRequest(BaseModel):
+    """Parsed scale API request info."""
+    root: str
+    mode: str
+    original_name: str
+    endpoint: str
+
+
+class ApiRequests(BaseModel):
+    """Container for parsed API requests from agent response."""
+    chords: List[ChordApiRequest] = []
+    scale: Optional[ScaleApiRequest] = None
+
+
+class ResumeRequest(BaseModel):
+    """Request for /api/agent/resume endpoint."""
+    response: str  # User's response to the clarifying question
+    thread_id: str = "default"
+
+
+class AgentResponse(BaseModel):
+    """Response for /api/agent/chat endpoint."""
+    answer: str
+    scale: Optional[str] = None
+    chord_choices: List[str] = []
+    visualizations: bool = False
+    out_of_scope: bool = False
+    interrupted: bool = False
+    interrupt_data: Optional[dict] = None
+    api_requests: Optional[ApiRequests] = None

--- a/backend/app/models/music.py
+++ b/backend/app/models/music.py
@@ -1,5 +1,8 @@
+"""
+Pydantic schemas for music theory endpoints (fretboard, tunings, scales, chords).
+"""
+
 from pydantic import BaseModel
-from typing import Optional, List
 
 
 class NotePosition(BaseModel):
@@ -73,8 +76,6 @@ class ScaleResponse(BaseModel):
     diatonic_chords: list[DiatonicChord]
 
 
-# Chord-related schemas
-
 class ChordQualityInfo(BaseModel):
     """Information about a chord quality."""
     id: str
@@ -113,58 +114,3 @@ class ChordResponse(BaseModel):
     display_name: str  # e.g., "Cmaj7", "Am"
     chord_notes: list[str]  # Notes in the chord
     caged_shapes: list[CagedShape]  # All 5 CAGED positions
-
-
-# Agent-related schemas
-
-class AgentMessage(BaseModel):
-    """A single message in a conversation."""
-    role: str  # "user" or "assistant"
-    content: str
-
-
-class AgentRequest(BaseModel):
-    """Request for /api/agent/chat endpoint."""
-    message: str
-    conversation_history: List[AgentMessage] = []
-    thread_id: Optional[str] = "default"  # For conversation tracking and interrupts
-
-
-class ChordApiRequest(BaseModel):
-    """Parsed chord API request info."""
-    root: str
-    quality: str
-    original_name: str
-    endpoint: str
-
-
-class ScaleApiRequest(BaseModel):
-    """Parsed scale API request info."""
-    root: str
-    mode: str
-    original_name: str
-    endpoint: str
-
-
-class ApiRequests(BaseModel):
-    """Container for parsed API requests from agent response."""
-    chords: List[ChordApiRequest] = []
-    scale: Optional[ScaleApiRequest] = None
-
-
-class ResumeRequest(BaseModel):
-    """Request for /api/agent/resume endpoint."""
-    response: str  # User's response to the clarifying question
-    thread_id: str = "default"
-
-
-class AgentResponse(BaseModel):
-    """Response for /api/agent/chat endpoint."""
-    answer: str
-    scale: Optional[str] = None
-    chord_choices: List[str] = []
-    visualizations: bool = False
-    out_of_scope: bool = False
-    interrupted: bool = False  # True if agent needs clarification from user
-    interrupt_data: Optional[dict] = None  # Contains clarifying_question and other interrupt info
-    api_requests: Optional[ApiRequests] = None  # Parsed API requests for frontend

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -1,10 +1,15 @@
 """
-Agent API routes.
+Agent API routes — synchronous and SSE streaming endpoints.
 """
 
-from fastapi import APIRouter, HTTPException
+import json
 import logging
 
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+from app.agent.agent import get_agent
+from app.agent.parser import build_api_requests_from_response
 from app.models.agent import (
     AgentRequest,
     AgentResponse,
@@ -13,100 +18,73 @@ from app.models.agent import (
     ScaleApiRequest,
     ResumeRequest,
 )
-from app.agent.agent import get_agent
-from app.agent.parser import build_api_requests_from_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+# --- Shared helpers ---
+
+def _build_agent_response(result: dict) -> AgentResponse:
+    """Build an AgentResponse from a raw agent result dict."""
+    if result.get("interrupted"):
+        return AgentResponse(
+            answer="",
+            interrupted=True,
+            interrupt_data=result.get("interrupt_data"),
+            visualizations=False,
+            out_of_scope=False,
+        )
+
+    api_requests_data = _parse_api_requests(result)
+
+    return AgentResponse(
+        answer=result["answer"],
+        scale=result.get("scale"),
+        chord_choices=result.get("chord_choices", []),
+        visualizations=result.get("visualizations", False),
+        out_of_scope=result.get("out_of_scope", False),
+        interrupted=False,
+        api_requests=api_requests_data,
+    )
+
+
+def _parse_api_requests(result: dict) -> ApiRequests | None:
+    """Parse chord/scale names into structured API request objects."""
+    has_chords = bool(result.get("chord_choices"))
+    has_scale = bool(result.get("scale"))
+
+    if (not has_chords and not has_scale) or result.get("out_of_scope"):
+        return None
+
+    parsed = build_api_requests_from_response(
+        chord_choices=result.get("chord_choices", []),
+        scale=result.get("scale"),
+        include_scale=True,
+    )
+
+    chord_requests = [ChordApiRequest(**c) for c in parsed.get("chords", [])]
+    scale_request = ScaleApiRequest(**parsed["scale"]) if parsed.get("scale") else None
+
+    return ApiRequests(chords=chord_requests, scale=scale_request)
+
+
+def _history_to_dicts(request: AgentRequest) -> list[dict]:
+    return [{"role": msg.role, "content": msg.content} for msg in request.conversation_history]
+
+
+# --- Synchronous endpoints ---
+
 @router.post("/agent/chat", response_model=AgentResponse)
 async def chat_with_agent(request: AgentRequest):
-    """
-    Chat with the Guitar Tutor agent.
-    
-    Args:
-        request: AgentRequest containing the user message, optional conversation history, and thread_id
-    
-    Returns:
-        AgentResponse with the agent's answer, structured data, parsed API requests, and interrupt info
-    """
-    try:
-        agent = get_agent()
-        
-        # Convert conversation history to dict format
-        history = [
-            {"role": msg.role, "content": msg.content}
-            for msg in request.conversation_history
-        ]
-        
-        result = agent.chat(
-            message=request.message,
-            conversation_history=history,
-            thread_id=request.thread_id
-        )
-        
-        # Check if interrupted
-        if result.get("interrupted"):
-            return AgentResponse(
-                answer="",
-                interrupted=True,
-                interrupt_data=result.get("interrupt_data"),
-                visualizations=False,
-                out_of_scope=False,
-            )
-        
-        # Parse chord/scale names into API requests
-        # Always build api_requests when we have chords or scale, not just when visualizations=true
-        api_requests_data = None
-        has_chords = bool(result.get("chord_choices"))
-        has_scale = bool(result.get("scale"))
-        if (has_chords or has_scale) and not result.get("out_of_scope"):
-            parsed = build_api_requests_from_response(
-                chord_choices=result.get("chord_choices", []),
-                scale=result.get("scale"),
-                include_scale=True
-            )
-            
-            # Convert to Pydantic models
-            chord_requests = [
-                ChordApiRequest(**chord)
-                for chord in parsed.get("chords", [])
-            ]
-            
-            scale_request = None
-            if parsed.get("scale"):
-                scale_request = ScaleApiRequest(**parsed["scale"])
-            
-            api_requests_data = ApiRequests(
-                chords=chord_requests,
-                scale=scale_request
-            )
-        
-        return AgentResponse(
-            answer=result["answer"],
-            scale=result.get("scale"),
-            chord_choices=result.get("chord_choices", []),
-            visualizations=result.get("visualizations", False),
-            out_of_scope=result.get("out_of_scope", False),
-            interrupted=False,
-            api_requests=api_requests_data,
-        )
-    
-    except ValueError as e:
-        # Missing API key or configuration error
-        logger.error(f"Agent configuration error: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Agent not configured properly. Please check OPENAI_API_KEY."
-        )
-    
-    except Exception as e:
-        logger.error(f"Agent error: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"An error occurred while processing your request: {str(e)}"
-        )
+    """Chat with the Guitar Tutor agent."""
+    agent = get_agent()
+    result = agent.chat(
+        message=request.message,
+        conversation_history=_history_to_dicts(request),
+        thread_id=request.thread_id,
+    )
+    return _build_agent_response(result)
 
 
 @router.get("/agent/health")
@@ -123,69 +101,86 @@ async def agent_health():
 
 @router.post("/agent/resume", response_model=AgentResponse)
 async def resume_agent_chat(request: ResumeRequest):
-    """
-    Resume agent chat after user answers a clarifying question.
-    
-    Args:
-        request: ResumeRequest containing the user's response and thread_id
-    
-    Returns:
-        AgentResponse with the agent's continued answer
-    """
-    try:
-        agent = get_agent()
-        
-        result = agent.resume_chat(
-            human_response=request.response,
-            thread_id=request.thread_id
-        )
-        
-        # Parse chord/scale names into API requests
-        api_requests_data = None
-        has_chords = bool(result.get("chord_choices"))
-        has_scale = bool(result.get("scale"))
-        if (has_chords or has_scale) and not result.get("out_of_scope"):
-            parsed = build_api_requests_from_response(
-                chord_choices=result.get("chord_choices", []),
-                scale=result.get("scale"),
-                include_scale=True
-            )
-            
-            # Convert to Pydantic models
-            chord_requests = [
-                ChordApiRequest(**chord)
-                for chord in parsed.get("chords", [])
-            ]
-            
-            scale_request = None
-            if parsed.get("scale"):
-                scale_request = ScaleApiRequest(**parsed["scale"])
-            
-            api_requests_data = ApiRequests(
-                chords=chord_requests,
-                scale=scale_request
-            )
-        
-        return AgentResponse(
-            answer=result["answer"],
-            scale=result.get("scale"),
-            chord_choices=result.get("chord_choices", []),
-            visualizations=result.get("visualizations", False),
-            out_of_scope=result.get("out_of_scope", False),
-            interrupted=False,
-            api_requests=api_requests_data,
-        )
-    
-    except ValueError as e:
-        logger.error(f"Agent configuration error: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Agent not configured properly. Please check OPENAI_API_KEY."
-        )
-    
-    except Exception as e:
-        logger.error(f"Agent resume error: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"An error occurred while resuming: {str(e)}"
-        )
+    """Resume agent chat after user answers a clarifying question."""
+    agent = get_agent()
+    result = agent.resume_chat(
+        human_response=request.response,
+        thread_id=request.thread_id,
+    )
+    return _build_agent_response(result)
+
+
+# --- SSE streaming endpoints ---
+
+@router.post("/agent/chat/stream")
+async def stream_chat_with_agent(request: AgentRequest):
+    """SSE streaming endpoint for agent chat."""
+
+    def event_generator():
+        try:
+            agent = get_agent()
+            for event in agent.stream_chat(
+                message=request.message,
+                conversation_history=_history_to_dicts(request),
+                thread_id=request.thread_id,
+            ):
+                event_type = event["event"]
+                data = event["data"]
+
+                # Enrich the final answer with parsed API requests
+                if event_type == "answer":
+                    data["api_requests"] = _serialize_api_requests(data)
+
+                yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+            yield "event: done\ndata: {}\n\n"
+
+        except Exception as e:
+            logger.exception(f"SSE stream error: {e}")
+            yield f"event: error\ndata: {json.dumps({'detail': str(e)})}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post("/agent/resume/stream")
+async def stream_resume_agent_chat(request: ResumeRequest):
+    """SSE streaming endpoint for resuming agent chat."""
+
+    def event_generator():
+        try:
+            agent = get_agent()
+            for event in agent.stream_resume(
+                human_response=request.response,
+                thread_id=request.thread_id,
+            ):
+                event_type = event["event"]
+                data = event["data"]
+
+                if event_type == "answer":
+                    data["api_requests"] = _serialize_api_requests(data)
+
+                yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+            yield "event: done\ndata: {}\n\n"
+
+        except Exception as e:
+            logger.exception(f"SSE resume stream error: {e}")
+            yield f"event: error\ndata: {json.dumps({'detail': str(e)})}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+def _serialize_api_requests(result: dict) -> dict | None:
+    """Parse and serialize API requests for SSE JSON output."""
+    api_requests = _parse_api_requests(result)
+    if api_requests is None:
+        return None
+    return api_requests.model_dump()

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -5,10 +5,9 @@ Agent API routes.
 from fastapi import APIRouter, HTTPException
 import logging
 
-from app.models.schemas import (
+from app.models.agent import (
     AgentRequest,
     AgentResponse,
-    AgentMessage,
     ApiRequests,
     ChordApiRequest,
     ScaleApiRequest,

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -93,7 +93,7 @@ async def agent_health():
     """Check if the agent is properly configured and ready."""
     try:
         agent = get_agent()
-        return {"status": "ready", "model": "gpt-4o-mini"}
+        return {"status": "ready", "model": agent.model_name}
     except ValueError as e:
         return {"status": "not_configured", "error": str(e)}
     except Exception as e:

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -78,6 +78,7 @@ def _history_to_dicts(request: AgentRequest) -> list[dict]:
 @router.post("/agent/chat", response_model=AgentResponse)
 async def chat_with_agent(request: AgentRequest):
     """Chat with the Guitar Tutor agent."""
+    logger.info(f"Chat request: thread={request.thread_id}, message={request.message[:80]}")
     agent = get_agent()
     result = agent.chat(
         message=request.message,
@@ -102,6 +103,7 @@ async def agent_health():
 @router.post("/agent/resume", response_model=AgentResponse)
 async def resume_agent_chat(request: ResumeRequest):
     """Resume agent chat after user answers a clarifying question."""
+    logger.info(f"Resume request: thread={request.thread_id}")
     agent = get_agent()
     result = agent.resume_chat(
         human_response=request.response,
@@ -115,6 +117,7 @@ async def resume_agent_chat(request: ResumeRequest):
 @router.post("/agent/chat/stream")
 async def stream_chat_with_agent(request: AgentRequest):
     """SSE streaming endpoint for agent chat."""
+    logger.info(f"Stream chat request: thread={request.thread_id}, message={request.message[:80]}")
 
     def event_generator():
         try:
@@ -149,6 +152,7 @@ async def stream_chat_with_agent(request: AgentRequest):
 @router.post("/agent/resume/stream")
 async def stream_resume_agent_chat(request: ResumeRequest):
     """SSE streaming endpoint for resuming agent chat."""
+    logger.info(f"Stream resume request: thread={request.thread_id}")
 
     def event_generator():
         try:

--- a/backend/app/routers/chords.py
+++ b/backend/app/routers/chords.py
@@ -4,7 +4,7 @@ Chords API routes.
 
 from fastapi import APIRouter, HTTPException
 
-from app.models.schemas import (
+from app.models.music import (
     ChordResponse,
     CagedShapePosition,
     CagedShape,

--- a/backend/app/routers/fretboard.py
+++ b/backend/app/routers/fretboard.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Query
 
-from app.models.schemas import FretboardResponse, NotePosition
+from app.models.music import FretboardResponse, NotePosition
 from app.music.notes import generate_fretboard
 from app.music.tunings import get_tuning_notes
 

--- a/backend/app/routers/scales.py
+++ b/backend/app/routers/scales.py
@@ -4,7 +4,7 @@ Scales API routes.
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.models.schemas import (
+from app.models.music import (
     ScalesListResponse,
     ScaleResponse,
     ScaleNotePosition,

--- a/backend/app/routers/tunings.py
+++ b/backend/app/routers/tunings.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.models.schemas import TuningsResponse, TuningInfo
+from app.models.music import TuningsResponse, TuningInfo
 from app.music.tunings import get_all_tunings
 
 router = APIRouter()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.114.0
 pydantic
+pydantic-settings
 python-dotenv==1.0.0
 langgraph==1.0.0
 langchain==1.0.0

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,10 +1,20 @@
 import type { FretboardResponse, TuningsResponse, ScalesListResponse, ScaleResponse, ChordResponse, ChordQualitiesResponse } from '../types';
-import type { AgentRequest, AgentResponse, ChatMessage, ResumeRequest } from '../types/chat';
+import type { AgentRequest, AgentResponse, ChatMessage, ResumeRequest, SseEvent } from '../types/chat';
 
 // Read base URL from Vite env at build-time (VITE_API_BASE_URL).
 // Use a relative URL by default so the browser calls the same origin (/api) and
 // nginx can proxy requests to the backend service in docker-compose.
 const API_BASE_URL = (import.meta.env as any).VITE_API_BASE_URL ?? '/api';
+
+// Human-readable labels for LangGraph node names emitted by the backend.
+export function nodeLabel(node: string): string {
+  const labels: Record<string, string> = {
+    prepare_question: 'Preparing...',
+    clarify:          'Thinking...',
+    generate_answer:  'Generating answer...',
+  };
+  return labels[node] ?? 'Thinking...';
+}
 
 class ApiClient {
   private baseUrl: string;
@@ -27,6 +37,81 @@ class ApiClient {
     }
 
     return response.json();
+  }
+
+  // Parses an SSE ReadableStream into typed SseEvent objects.
+  private async *_parseSseStream(body: ReadableStream<Uint8Array>): AsyncGenerator<SseEvent> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let currentEvent = '';
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!; // keep the incomplete trailing line
+
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
+            const data = JSON.parse(line.slice(6));
+            yield { event: currentEvent, data } as SseEvent;
+            currentEvent = '';
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  // Sends a POST request to an SSE endpoint and resolves with the final AgentResponse.
+  // Calls onStatus for each intermediate status event so the UI can show progress.
+  private async _runStream(
+    endpoint: string,
+    body: object,
+    onStatus?: (node: string) => void,
+  ): Promise<AgentResponse> {
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    if (!response.body) {
+      throw new Error('No response body from stream endpoint');
+    }
+
+    for await (const event of this._parseSseStream(response.body)) {
+      if (event.event === 'status') {
+        onStatus?.(event.data.node);
+      } else if (event.event === 'interrupt') {
+        return {
+          answer: '',
+          scale: null,
+          chord_choices: [],
+          visualizations: false,
+          out_of_scope: false,
+          interrupted: true,
+          interrupt_data: event.data,
+        };
+      } else if (event.event === 'answer') {
+        return event.data;
+      } else if (event.event === 'error') {
+        throw new Error(event.data.detail);
+      }
+      // 'done' — stream finished normally after 'answer', nothing to do
+    }
+
+    throw new Error('Stream ended without an answer event');
   }
 
   async getFretboard(tuning: string = 'standard'): Promise<FretboardResponse> {
@@ -53,7 +138,12 @@ class ApiClient {
     return this.fetch<ChordResponse>(`/chords/${encodeURIComponent(root)}/${encodeURIComponent(quality)}`);
   }
 
-  async chat(message: string, conversationHistory: ChatMessage[] = [], threadId: string = 'default'): Promise<AgentResponse> {
+  async streamChat(
+    message: string,
+    conversationHistory: ChatMessage[] = [],
+    threadId: string = 'default',
+    onStatus?: (node: string) => void,
+  ): Promise<AgentResponse> {
     const request: AgentRequest = {
       message,
       conversation_history: conversationHistory.map(msg => ({
@@ -62,23 +152,16 @@ class ApiClient {
       })),
       thread_id: threadId,
     };
-
-    return this.fetch<AgentResponse>('/agent/chat', {
-      method: 'POST',
-      body: JSON.stringify(request),
-    });
+    return this._runStream('/agent/chat/stream', request, onStatus);
   }
 
-  async resumeChat(response: string, threadId: string = 'default'): Promise<AgentResponse> {
-    const request: ResumeRequest = {
-      response,
-      thread_id: threadId,
-    };
-
-    return this.fetch<AgentResponse>('/agent/resume', {
-      method: 'POST',
-      body: JSON.stringify(request),
-    });
+  async streamResume(
+    response: string,
+    threadId: string = 'default',
+    onStatus?: (node: string) => void,
+  ): Promise<AgentResponse> {
+    const request: ResumeRequest = { response, thread_id: threadId };
+    return this._runStream('/agent/resume/stream', request, onStatus);
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -71,11 +71,12 @@ class ApiClient {
   }
 
   // Sends a POST request to an SSE endpoint and resolves with the final AgentResponse.
-  // Calls onStatus for each intermediate status event so the UI can show progress.
+  // Calls onStatus for intermediate status events and onToken for streamed text tokens.
   private async _runStream(
     endpoint: string,
     body: object,
     onStatus?: (node: string) => void,
+    onToken?: (text: string) => void,
   ): Promise<AgentResponse> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       method: 'POST',
@@ -93,6 +94,8 @@ class ApiClient {
     for await (const event of this._parseSseStream(response.body)) {
       if (event.event === 'status') {
         onStatus?.(event.data.node);
+      } else if (event.event === 'token') {
+        onToken?.(event.data.text);
       } else if (event.event === 'interrupt') {
         return {
           answer: '',
@@ -143,6 +146,7 @@ class ApiClient {
     conversationHistory: ChatMessage[] = [],
     threadId: string = 'default',
     onStatus?: (node: string) => void,
+    onToken?: (text: string) => void,
   ): Promise<AgentResponse> {
     const request: AgentRequest = {
       message,
@@ -152,16 +156,17 @@ class ApiClient {
       })),
       thread_id: threadId,
     };
-    return this._runStream('/agent/chat/stream', request, onStatus);
+    return this._runStream('/agent/chat/stream', request, onStatus, onToken);
   }
 
   async streamResume(
     response: string,
     threadId: string = 'default',
     onStatus?: (node: string) => void,
+    onToken?: (text: string) => void,
   ): Promise<AgentResponse> {
     const request: ResumeRequest = { response, thread_id: threadId };
-    return this._runStream('/agent/resume/stream', request, onStatus);
+    return this._runStream('/agent/resume/stream', request, onStatus, onToken);
   }
 }
 

--- a/frontend/src/components/Chat/ChatPanel.tsx
+++ b/frontend/src/components/Chat/ChatPanel.tsx
@@ -7,6 +7,7 @@ import type { ChatMessage as ChatMessageType } from '../../types/chat';
 interface ChatPanelProps {
   messages: ChatMessageType[];
   isLoading: boolean;
+  streamingStatus?: string | null;
   onSendMessage: (message: string) => void;
   onChordClick?: (chord: string, apiRequest?: { root: string; quality: string }) => void;
   onScaleClick?: (scale: string, apiRequest?: { root: string; mode: string }) => void;
@@ -24,6 +25,7 @@ interface ChatPanelProps {
 export function ChatPanel({
   messages,
   isLoading,
+  streamingStatus,
   onSendMessage,
   onChordClick,
   onScaleClick,
@@ -187,9 +189,9 @@ export function ChatPanel({
             {/* Loading indicator */}
             {isLoading && (
               <div className="flex justify-start mb-3">
-                <div 
+                <div
                   className="rounded-2xl rounded-bl-sm px-4 py-3 border"
-                  style={{ 
+                  style={{
                     backgroundColor: 'var(--card-bg)',
                     borderColor: 'var(--border-primary)',
                     boxShadow: 'var(--shadow-sm)'
@@ -200,6 +202,11 @@ export function ChatPanel({
                     <div className="w-2 h-2 rounded-full animate-bounce" style={{ animationDelay: '150ms', backgroundColor: 'var(--accent-400)' }} />
                     <div className="w-2 h-2 rounded-full animate-bounce" style={{ animationDelay: '300ms', backgroundColor: 'var(--accent-400)' }} />
                   </div>
+                  {streamingStatus && (
+                    <p className="text-xs mt-1.5" style={{ color: 'var(--text-muted)' }}>
+                      {streamingStatus}
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/components/Chat/ChatPanel.tsx
+++ b/frontend/src/components/Chat/ChatPanel.tsx
@@ -90,8 +90,10 @@ export function ChatPanel({
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" style={{ color: 'var(--accent-600)' }}>
-              <path d="M10 3.75a2 2 0 10-4 0 2 2 0 004 0zM17.25 4.5a.75.75 0 000-1.5h-5.5a.75.75 0 000 1.5h5.5zM5 3.75a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 01.75.75zM4.25 17a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5h1.5zM17.25 17a.75.75 0 000-1.5h-5.5a.75.75 0 000 1.5h5.5zM9 10a.75.75 0 01-.75.75h-5.5a.75.75 0 010-1.5h5.5A.75.75 0 019 10zM17.25 10.75a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5h1.5zM14 10a2 2 0 10-4 0 2 2 0 004 0zM10 16.25a2 2 0 10-4 0 2 2 0 004 0z" />
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5" style={{ color: 'var(--accent-600)' }}>
+              <path d="M9 18V5l12-2v13" />
+              <circle cx="6" cy="18" r="3" fill="currentColor" />
+              <circle cx="18" cy="16" r="3" fill="currentColor" />
             </svg>
             <h2 className="font-semibold" style={{ color: 'var(--text-primary)' }}>AI Guitar Tutor</h2>
           </div>

--- a/frontend/src/components/layout/ChatSidebar.tsx
+++ b/frontend/src/components/layout/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import { ChatPanel } from '../Chat';
-import { useAppStore } from '../../stores';
+import { useAppStore, useStreamingStatus } from '../../stores';
 
 interface ChatSidebarProps {
   onSendMessage: (message: string) => void;
@@ -26,6 +26,7 @@ export function ChatSidebar({
     selectedRoot,
     selectedMode,
   } = useAppStore();
+  const streamingStatus = useStreamingStatus();
 
   return (
     <aside
@@ -35,6 +36,7 @@ export function ChatSidebar({
       <ChatPanel
         messages={messages}
         isLoading={chatLoading}
+        streamingStatus={streamingStatus}
         onSendMessage={onSendMessage}
         onChordClick={onChordClick}
         onScaleClick={onScaleClick}
@@ -120,6 +122,7 @@ export function MobileChatSheet({
     selectedRoot,
     selectedMode,
   } = useAppStore();
+  const streamingStatus = useStreamingStatus();
 
   const handleClose = () => setMobileSheetOpen(false);
 
@@ -160,6 +163,7 @@ export function MobileChatSheet({
           <ChatPanel
             messages={messages}
             isLoading={chatLoading}
+            streamingStatus={streamingStatus}
             onSendMessage={onSendMessage}
             onChordClick={(chord, apiRequest) => {
               onChordClick?.(chord, apiRequest);

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -14,5 +14,6 @@ export {
   useActiveChordShapes,
   useChatMessages,
   useChatLoading,
+  useStreamingStatus,
   useChatPanelState,
 } from './useAppStore';

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import { apiClient } from '../api/client';
-import type { 
+import { apiClient, nodeLabel } from '../api/client';
+import type {
   ScaleResponse, 
   ChordResponse, 
   DiatonicChord, 
@@ -90,10 +90,10 @@ interface ChordSlice {
 interface ChatSlice {
   messages: ChatMessage[];
   chatLoading: boolean;
+  streamingStatus: string | null;
   threadId: string;  // For tracking conversation with interrupts
   addMessage: (message: ChatMessage) => void;
   sendMessage: (message: string) => Promise<ChatMessage | null>;
-  resumeMessage: (response: string) => Promise<ChatMessage | null>;
   resetChat: () => void;
   setThreadId: (id: string) => void;
 }
@@ -265,6 +265,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   // --------------------------------------------------------------------------
   messages: [],
   chatLoading: false,
+  streamingStatus: null,
   threadId: 'default',
   
   addMessage: (message) => {
@@ -275,31 +276,33 @@ export const useAppStore = create<AppStore>((set, get) => ({
   
   sendMessage: async (message) => {
     const { messages, threadId } = get();
-    
+
     // Check if the last assistant message was interrupted (waiting for clarification)
     const lastAssistantMessage = [...messages].reverse().find(m => m.role === 'assistant');
     const isResumingFromInterrupt = lastAssistantMessage?.interrupted;
-    
-    // Add user message
+
+    // Add user message immediately
     const userMessage: ChatMessage = {
       id: generateMessageId(),
       role: 'user',
       content: message,
       timestamp: new Date(),
     };
-    
-    set((state) => ({ 
+
+    set((state) => ({
       messages: [...state.messages, userMessage],
-      chatLoading: true 
+      chatLoading: true,
+      streamingStatus: null,
     }));
 
+    const onStatus = (node: string) => set({ streamingStatus: nodeLabel(node) });
+
     try {
-      // If resuming from interrupt, use resume endpoint, otherwise use regular chat
-      const response = isResumingFromInterrupt 
-        ? await apiClient.resumeChat(message, threadId)
-        : await apiClient.chat(message, messages, threadId);
-      
-      // Handle interrupted response (clarifying question)
+      const response = isResumingFromInterrupt
+        ? await apiClient.streamResume(message, threadId, onStatus)
+        : await apiClient.streamChat(message, messages, threadId, onStatus);
+
+      // Handle interrupted response (agent asking a clarifying question)
       if (response.interrupted) {
         const assistantMessage: ChatMessage = {
           id: generateMessageId(),
@@ -309,15 +312,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
           interrupted: true,
           interruptData: response.interrupt_data,
         };
-        
-        set((state) => ({ 
+
+        set((state) => ({
           messages: [...state.messages, assistantMessage],
-          chatLoading: false 
+          chatLoading: false,
+          streamingStatus: null,
         }));
-        
+
         return assistantMessage;
       }
-      
+
       // Normal response
       const assistantMessage: ChatMessage = {
         id: generateMessageId(),
@@ -330,84 +334,30 @@ export const useAppStore = create<AppStore>((set, get) => ({
         outOfScope: response.out_of_scope,
         apiRequests: response.api_requests,
       };
-      
-      set((state) => ({ 
+
+      set((state) => ({
         messages: [...state.messages, assistantMessage],
-        chatLoading: false 
+        chatLoading: false,
+        streamingStatus: null,
       }));
-      
+
       return assistantMessage;
     } catch (err) {
       console.error('Chat error:', err);
-      
+
       const errorMessage: ChatMessage = {
         id: generateMessageId(),
         role: 'assistant',
         content: 'Sorry, I encountered an error. Please make sure the backend is running.',
         timestamp: new Date(),
       };
-      
-      set((state) => ({ 
-        messages: [...state.messages, errorMessage],
-        chatLoading: false 
-      }));
-      
-      return null;
-    }
-  },
 
-  resumeMessage: async (response) => {
-    const { threadId } = get();
-    
-    // Add user's clarification response
-    const userMessage: ChatMessage = {
-      id: generateMessageId(),
-      role: 'user',
-      content: response,
-      timestamp: new Date(),
-    };
-    
-    set((state) => ({ 
-      messages: [...state.messages, userMessage],
-      chatLoading: true 
-    }));
-
-    try {
-      const apiResponse = await apiClient.resumeChat(response, threadId);
-      
-      const assistantMessage: ChatMessage = {
-        id: generateMessageId(),
-        role: 'assistant',
-        content: apiResponse.answer,
-        timestamp: new Date(),
-        scale: apiResponse.scale,
-        chordChoices: apiResponse.chord_choices,
-        visualizations: apiResponse.visualizations,
-        outOfScope: apiResponse.out_of_scope,
-        apiRequests: apiResponse.api_requests,
-      };
-      
-      set((state) => ({ 
-        messages: [...state.messages, assistantMessage],
-        chatLoading: false 
-      }));
-      
-      return assistantMessage;
-    } catch (err) {
-      console.error('Resume chat error:', err);
-      
-      const errorMessage: ChatMessage = {
-        id: generateMessageId(),
-        role: 'assistant',
-        content: 'Sorry, I encountered an error while continuing our conversation.',
-        timestamp: new Date(),
-      };
-      
-      set((state) => ({ 
+      set((state) => ({
         messages: [...state.messages, errorMessage],
-        chatLoading: false 
+        chatLoading: false,
+        streamingStatus: null,
       }));
-      
+
       return null;
     }
   },
@@ -456,6 +406,7 @@ export const useActiveChordShapes = () => useAppStore((state) => state.activeCho
 // Chat selectors
 export const useChatMessages = () => useAppStore((state) => state.messages);
 export const useChatLoading = () => useAppStore((state) => state.chatLoading);
+export const useStreamingStatus = () => useAppStore((state) => state.streamingStatus);
 
 // Chat panel selectors
 export const useChatPanelState = () => useAppStore((state) => ({

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -288,6 +288,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       content: message,
       timestamp: new Date(),
     };
+    const streamingMsgId = generateMessageId();
 
     set((state) => ({
       messages: [...state.messages, userMessage],
@@ -297,63 +298,92 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     const onStatus = (node: string) => set({ streamingStatus: nodeLabel(node) });
 
+    const onToken = (text: string) => {
+      set((state) => {
+        const msgs = [...state.messages];
+        const lastMsg = msgs[msgs.length - 1];
+
+        if (lastMsg?.id === streamingMsgId) {
+          msgs[msgs.length - 1] = { ...lastMsg, content: lastMsg.content + text };
+        } else {
+          // First token — create the streaming message
+          msgs.push({
+            id: streamingMsgId,
+            role: 'assistant',
+            content: text,
+            timestamp: new Date(),
+          });
+        }
+
+        return { messages: msgs, chatLoading: false, streamingStatus: null };
+      });
+    };
+
     try {
       const response = isResumingFromInterrupt
-        ? await apiClient.streamResume(message, threadId, onStatus)
-        : await apiClient.streamChat(message, messages, threadId, onStatus);
+        ? await apiClient.streamResume(message, threadId, onStatus, onToken)
+        : await apiClient.streamChat(message, messages, threadId, onStatus, onToken);
 
       // Handle interrupted response (agent asking a clarifying question)
       if (response.interrupted) {
-        const assistantMessage: ChatMessage = {
-          id: generateMessageId(),
-          role: 'assistant',
-          content: response.interrupt_data?.clarifying_question || 'I need more information to help you.',
-          timestamp: new Date(),
-          interrupted: true,
-          interruptData: response.interrupt_data,
-        };
-
         set((state) => ({
-          messages: [...state.messages, assistantMessage],
+          messages: [
+            ...state.messages.filter(m => m.id !== streamingMsgId),
+            {
+              id: generateMessageId(),
+              role: 'assistant' as const,
+              content: response.interrupt_data?.clarifying_question || 'I need more information to help you.',
+              timestamp: new Date(),
+              interrupted: true,
+              interruptData: response.interrupt_data,
+            },
+          ],
           chatLoading: false,
           streamingStatus: null,
         }));
 
-        return assistantMessage;
+        return get().messages[get().messages.length - 1];
       }
 
-      // Normal response
-      const assistantMessage: ChatMessage = {
-        id: generateMessageId(),
-        role: 'assistant',
-        content: response.answer,
-        timestamp: new Date(),
-        scale: response.scale,
-        chordChoices: response.chord_choices,
-        visualizations: response.visualizations,
-        outOfScope: response.out_of_scope,
-        apiRequests: response.api_requests,
-      };
+      // Finalize the streaming message with metadata, or create if no tokens were streamed
+      set((state) => {
+        const msgs = [...state.messages];
+        const idx = msgs.findIndex(m => m.id === streamingMsgId);
+        const finalMessage: ChatMessage = {
+          id: streamingMsgId,
+          role: 'assistant',
+          content: response.answer,
+          timestamp: new Date(),
+          scale: response.scale,
+          chordChoices: response.chord_choices,
+          visualizations: response.visualizations,
+          outOfScope: response.out_of_scope,
+          apiRequests: response.api_requests,
+        };
 
-      set((state) => ({
-        messages: [...state.messages, assistantMessage],
-        chatLoading: false,
-        streamingStatus: null,
-      }));
+        if (idx >= 0) {
+          msgs[idx] = finalMessage;
+        } else {
+          msgs.push(finalMessage);
+        }
 
-      return assistantMessage;
+        return { messages: msgs, chatLoading: false, streamingStatus: null };
+      });
+
+      return get().messages.find(m => m.id === streamingMsgId) ?? null;
     } catch (err) {
       console.error('Chat error:', err);
 
-      const errorMessage: ChatMessage = {
-        id: generateMessageId(),
-        role: 'assistant',
-        content: 'Sorry, I encountered an error. Please make sure the backend is running.',
-        timestamp: new Date(),
-      };
-
       set((state) => ({
-        messages: [...state.messages, errorMessage],
+        messages: [
+          ...state.messages.filter(m => m.id !== streamingMsgId),
+          {
+            id: generateMessageId(),
+            role: 'assistant' as const,
+            content: 'Sorry, I encountered an error. Please make sure the backend is running.',
+            timestamp: new Date(),
+          },
+        ],
         chatLoading: false,
         streamingStatus: null,
       }));

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -67,6 +67,7 @@ export interface ResumeRequest {
 // SSE wire-format event types (matches backend stream endpoints)
 export type SseEvent =
   | { event: 'status';    data: { node: string } }
+  | { event: 'token';     data: { text: string } }
   | { event: 'interrupt'; data: { clarifying_question?: string; action?: string } }
   | { event: 'answer';    data: AgentResponse }
   | { event: 'error';     data: { detail: string } }

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -63,3 +63,11 @@ export interface ResumeRequest {
   response: string;  // User's answer to clarifying question
   thread_id: string;
 }
+
+// SSE wire-format event types (matches backend stream endpoints)
+export type SseEvent =
+  | { event: 'status';    data: { node: string } }
+  | { event: 'interrupt'; data: { clarifying_question?: string; action?: string } }
+  | { event: 'answer';    data: AgentResponse }
+  | { event: 'error';     data: { detail: string } }
+  | { event: 'done';      data: Record<string, never> };


### PR DESCRIPTION
- Backend refactor: Extract config, exceptions, and models into separate modules; split schemas by domain; DRY up agent router with shared helpers
- OpenRouter support: Add LLM_PROVIDER toggle to switch between OpenAI and OpenRouter with auto-resolved base URLs, API keys, and default models
- Token streaming: Split answer generation into text + metadata LLM calls so the answer text streams token-by-token over SSE, with chord/scale metadata arriving at the end
- SSE migration: Move frontend chat from polling to SSE streaming with real-time status updates and progressive text rendering