### PR TITLE
Feature/song view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ lib-cov/
 # Vite
 *.local
 agent-test/
+
+samples/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guitar Tutor
 
-An interactive web app for learning guitar music theory. Pick a scale or chord, see it on the fretboard, and chat with an AI tutor that can answer questions and update the board in real time.
+An interactive web app for learning guitar music theory. Pick a scale or chord, see it on the fretboard, search for songs with real tabs, and chat with an AI tutor that can answer questions and update the board in real time.
 
 ![React](https://img.shields.io/badge/React-19-blue) ![FastAPI](https://img.shields.io/badge/FastAPI-0.114-green) ![Python](https://img.shields.io/badge/Python-3.12-yellow) ![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue)
 
@@ -10,7 +10,9 @@ An interactive web app for learning guitar music theory. Pick a scale or chord, 
 - **Scale explorer** — 14+ scales with diatonic chord generation. Select a scale and see every note highlighted across the neck.
 - **Chord visualizer** — 18+ chord qualities powered by a curated voicing database. Explore real guitar voicings across positions on the neck.
 - **Voicing filtering** — Toggle individual voicings on/off, isolate one position, or view all voicings together.
-- **AI tutor chat** — Ask questions about music theory and get answers that automatically update the fretboard. Suggestions come as clickable pills you can tap to load instantly.
+- **Song view** — Search for songs via Songsterr, browse tracks, and view tablature with a scrollable measure-by-measure tab viewer. Selecting a beat highlights the corresponding notes on the fretboard. Tuning auto-detects from the track. Switch between tab and chord/lyric views (ChordPro).
+- **AI tutor chat** — Ask questions about music theory and get answers that automatically update the fretboard. The agent can search for songs, navigate to specific measures, and highlight fret positions directly on the board. Suggestions come as clickable pills you can tap to load instantly.
+- **Agent fretboard highlights** — The tutor can overlay named highlight groups (chord shapes, scale boxes, voicings) on the fretboard with a carousel to cycle through alternatives.
 - **Mobile friendly** — Responsive layout with a slide-up chat panel on small screens.
 
 ## Tech stack
@@ -70,14 +72,38 @@ The backend exposes a few endpoints — full docs available at `/docs` when the 
 - `GET /api/fretboard` — Full chromatic fretboard grid
 - `GET /api/scales/{root}/{mode}` — Scale positions + diatonic chords
 - `GET /api/chords/{root}/{quality}` — Chord positions with database-backed voicings
+- `GET /api/tunings` — Available guitar tunings
+- `GET /api/songs/search?q=...` — Search songs via Songsterr
+- `GET /api/songs/{id}/tracks` — Track list for a song
+- `GET /api/songs/{id}/tab?track=0` — Tab data for a specific track
+- `GET /api/songs/{id}/chords` — ChordPro lyrics + chords
 - `POST /api/agent/chat` — Send a message to the AI tutor
+- `POST /api/agent/chat/stream` — SSE streaming chat
+- `POST /api/agent/resume` — Resume after a clarifying question
+
+## Agent architecture
+
+The AI tutor is a LangGraph state graph with three nodes:
+
+```
+START -> prepare_question -> clarify_input -> generate_answer -> END
+```
+
+1. **prepare_question** — Gate node. Classifies the user's message as proceed, needs-clarification, or out-of-scope. Uses a running conversation summary and UI context (selected scale/chord/song, playhead position) to make the decision.
+2. **clarify_input** — If the gate requested clarification, this node interrupts the graph (LangGraph `interrupt`) and returns the question to the user. When the user responds, the graph resumes and routes to `generate_answer`.
+3. **generate_answer** — Multi-step answer generation:
+   - **Song tool planning** — An LLM call decides whether to search for a song or navigate to a measure, producing action payloads the frontend executes.
+   - **Answer text** — The main LLM call generates the teaching response, grounded in conversation summary, UI context, and any tool results.
+   - **Post-processing** — A structured output call extracts metadata (scale name, chord choices, visualization flag) and fretboard highlight groups (named sets of string/fret positions) in one pass.
+
+The agent supports both synchronous and SSE streaming endpoints. Conversation state is checkpointed per thread (in-memory or SQLite) so multi-turn context survives across requests.
 
 ## Project structure
 
 ```
 ├── frontend/
 │   ├── src/
-│   │   ├── components/       # Fretboard, Chat, Selectors, Layout
+│   │   ├── components/       # Fretboard, Chat, Selectors, Song, TabViewer, Layout
 │   │   ├── stores/           # Zustand state (slices per domain)
 │   │   ├── api/              # API client
 │   │   ├── types/            # TypeScript interfaces
@@ -86,9 +112,10 @@ The backend exposes a few endpoints — full docs available at `/docs` when the 
 │
 ├── backend/
 │   ├── app/
-│   │   ├── routers/          # FastAPI route handlers
-│   │   ├── music/            # Theory engine (scales, chords, tunings)
-│   │   ├── agent/            # LangGraph AI tutor
+│   │   ├── routers/          # Thin FastAPI route handlers
+│   │   ├── services/         # Business logic (scale, chord, fretboard, songsterr)
+│   │   ├── music/            # Pure music theory engine (scales, chords, tunings, notes)
+│   │   ├── agent/            # LangGraph AI tutor (graph, parser)
 │   │   └── models/           # Pydantic schemas
 │   └── requirements.txt
 │
@@ -98,6 +125,8 @@ The backend exposes a few endpoints — full docs available at `/docs` when the 
 ## Design decisions
 
 - **Backend-driven theory** — All music theory calculations (scale formulas, chord notes, voicing adaptation) live on the backend. The frontend is a display layer.
+- **Service layer** — Routers are thin (validate input, call service, return result). Business logic lives in `services/` so it can be shared between HTTP endpoints and the agent.
 - **CSS Grid fretboard** — The fretboard is built with Tailwind's CSS Grid, not SVG or canvas. Simpler to style and naturally responsive.
-- **LangGraph agent** — The AI tutor uses a two-node state graph so it can pause to ask clarifying questions before answering.
-- **Zustand over Redux** — Lightweight state management split into domain slices (scale, chord, chat, UI) without the boilerplate.
+- **LangGraph agent** — The AI tutor uses a three-node state graph (gate, interrupt, answer) with conversation summarization and checkpointed threads for multi-turn memory.
+- **Song-fretboard bridge** — Selecting a beat in the tab viewer highlights notes on the fretboard. The agent can also emit highlight groups and song navigation actions that the frontend applies automatically.
+- **Zustand over Redux** — Lightweight state management split into domain slices (scale, chord, song, chat, UI, agent highlights) without the boilerplate.

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -18,7 +18,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from app.agent.parser import parse_chord_name, parse_scale_name
 from app.config import get_settings
@@ -45,24 +45,52 @@ class ThreadNotFoundError(RuntimeError):
 class PreppedQuestionSchema(TypedDict):
     """Schema for the prepare_question node output."""
 
-    question_for_llm: Optional[str] = Field(None, description="A concise guitar/music-theory question")
     out_of_scope: bool = Field(False, description="Whether the question is out of scope")
-    clarifying_question: Optional[str] = Field(None, description="A clarifying question if needed")
+    clarifying_question_for_user: Optional[str] = Field(None, description="A clarifying question to send to the user")
 
 
-class AnswerMetadataSchema(TypedDict):
-    """Schema for answer metadata extraction (scale, chords, visualizations)."""
+class SongToolPlanSchema(BaseModel):
+    """Structured song-tool intent chosen during answer generation."""
+
+    song_search_query: Optional[str] = Field(
+        None,
+        description=(
+            "Search query for a specific song the user wants opened in the song UI, "
+            "for example 'frisky dominic fike'. Null when no song lookup is needed."
+        ),
+    )
+    focus_measure_number: Optional[int] = Field(
+        None,
+        description=(
+            "1-based measure number the user wants focused in the currently selected or requested song. "
+            "Null when no measure navigation is needed."
+        ),
+    )
+
+
+class FretboardHighlightPositionSchema(TypedDict):
+    string: int
+    fret: int
+
+
+class FretboardHighlightGroupSchema(TypedDict):
+    name: str
+    positions: List[FretboardHighlightPositionSchema]
+
+
+class AnswerPostProcessSchema(TypedDict):
+    """Combined schema for metadata extraction + fretboard highlights in one call."""
 
     scale: Optional[str] = Field(None, description="Most relevant scale name")
     chord_choices: List[str] = Field(default_factory=list, description="List of chord names recommended")
     visualizations: bool = Field(False, description="Whether visualizations are needed")
+    highlight_groups: List[FretboardHighlightGroupSchema] = Field(default_factory=list, description="Fretboard highlight groups")
 
 
 class OverallState(MessagesState):
     """Overall state for the agent graph."""
 
-    question_for_llm: Optional[str] = None
-    clarifying_question: Optional[str] = None
+    clarifying_question_for_user: Optional[str] = None
     answer: str = ""
     scale: Optional[str] = None
     chord_choices: List[str] = []
@@ -81,39 +109,55 @@ class OverallState(MessagesState):
 
 # --- Prompt templates ---
 
-PREP_QUESTION_INSTRUCTIONS = """You are the Guitar Tutor question normalizer. You will ONLY prepare a single, concise MUSIC THEORY / GUITAR question for the NEXT node to answer — do NOT answer the question yourself.
+PREP_QUESTION_INSTRUCTIONS = """You are the Guitar Tutor gate. Decide whether to proceed, clarify, or reject the user's question. Do NOT answer the question yourself.
 
-Inputs available to you (replace in runtime):
+Inputs:
 - running_summary: {running_summary}
 - previous_context: {previous_context}
 - ui_context: {ui_context}
 - user_question: {user_question}
 
-Output requirements (JSON ONLY): produce exactly one of these three JSON shapes and nothing else. Use canonical chord/scale names when relevant. Keep output <= 20 words when possible.
+Return JSON ONLY. Produce exactly one of these shapes:
+1) Proceed (preferred)
+{{"out_of_scope": false}}
 
-1) Clear music/guitar question — STRONGLY PREFERRED. Use your best judgment to fill in any gaps.
-{{"question_for_llm": "<<= 20 words, concise guitar/music-theory question>", "out_of_scope": false}}
-
-2) Need clarification — LAST RESORT ONLY. Use this ONLY when you truly cannot proceed (e.g., the question is so vague that any assumption would be misleading).
-{{"clarifying_question": "<one short clarifying question>", "out_of_scope": false}}
+2) Need clarification
+{{"clarifying_question_for_user": "<one short clarifying question>", "out_of_scope": false}}
 
 3) Out of scope
 {{"out_of_scope": true}}
 
-Best judgment guidelines:
-- PREFER producing question_for_llm over asking for clarification. Make reasonable assumptions and move forward.
-- Treat ui_context as a trusted runtime source of truth for current app/song/beat state whenever available.
-- If details are missing in user text but present in ui_context, use ui_context and continue instead of asking clarification.
-- If the user omits details like tuning, assume standard tuning unless ui_context indicates otherwise.
-- If ui_context has active song/track state and user asks about "this song", keep that context.
-- If user asks deictic questions like "What chord is this?" and ui_context includes selected_beat_id/highlighted_notes, keep that selected-beat context explicit.
-- Do not invent or renumber measure/beat references if selected_beat_id already provides concrete context.
-- If the user asks to search/find/show/display a song or tab, preserve that intent explicitly in question_for_llm (e.g., include artist/title clue).
-- If the user asks to show a section or measure, preserve the requested measure reference in question_for_llm.
-- Only use clarifying_question when the request is genuinely too vague to make ANY reasonable assumption.
-- If the user's request is not music, guitar, songs, tabs, measures, or music theory related, return out_of_scope true.
-- If you provide clarifying_question, do not provide question_for_llm.
-- Do NOT include voicings, diagrams, notes, or additional metadata.
+Guidelines:
+- Default to proceeding. Trust the answer model's judgement to handle ambiguity, fill in gaps, and make creative choices.
+- Never clarify about format, notation style, or level of detail — just proceed.
+- Never clarify to confirm intent — if the user mentions a song, artist, chord, scale, or technique, proceed.
+- Only clarify when the question is genuinely unanswerable without more info (e.g. "help me with this" with zero context).
+- For a pure greeting with no music content, use clarifying_question_for_user to greet briefly and ask what guitar/music help they want.
+- If the request is not about music, guitar, songs, tabs, measures, or music theory, return out_of_scope true.
+"""
+
+SONG_TOOL_INTENT_INSTRUCTIONS = """You are deciding whether the Guitar Tutor should use song UI tools before answering. Do NOT answer the user.
+
+Inputs:
+- running_summary: {running_summary}
+- previous_context: {previous_context}
+- ui_context: {ui_context}
+- user_question: {user_question}
+
+Return JSON ONLY with this exact shape:
+{{
+  "song_search_query": string | null,
+  "focus_measure_number": integer | null
+}}
+
+Rules:
+- Use "song_search_query" when the user wants to open, load, search, show, display, or learn a specific song/tab in the Songs UI.
+- Natural teaching phrasing still counts as song intent. Example: "show me how to play wonderwall" should return {{"song_search_query": "wonderwall", "focus_measure_number": null}}.
+- Include artist names when they are present or clearly implied. Example: "teach me frisky by dominic fike" -> "frisky dominic fike".
+- Do NOT set song_search_query for theory-only requests like chords, scales, intervals, fretboard notes, or generic techniques.
+- Use "focus_measure_number" only when the user explicitly asks to jump to, show, start at, or focus a numbered measure in a song.
+- Measure numbers are 1-based in your output.
+- If no song tool is needed, return null for both fields.
 """
 
 ANSWER_TEXT_INSTRUCTIONS = """You are the Guitar Tutor. Answer the user's guitar/music theory question.
@@ -123,31 +167,56 @@ Hard constraints:
 - Keep output concise: 1-3 paragraphs.
 
 Inputs:
-- Question: {user_question}
 - Running summary: {running_summary}
 - UI context: {ui_context}
 - Tool context: {tool_context}
 
 Behavior:
 - Be clear and pedagogical. Explain WHY choices work.
-- Treat ui_context as authoritative for current selection/playhead/highlighted notes when present.
-- If a concrete song/tool lookup succeeded, ground your answer in those results.
-- If a lookup failed, explain the limitation briefly and continue with the best fallback guidance.
-- If user intent is song search/display, briefly name the matched song/artist (if known) and what the UI will show next.
-- If user intent is measure/section focus, explicitly mention the measure target and any assumptions made.
-- Do NOT say you lack direct tab database access. You are integrated with a song-tab lookup tool in this application.
-- For deictic questions ("this chord", "this beat"), prioritize ui_context.selected_beat_id/highlighted_notes as the reference.
+- The user's explicit intent always takes priority over the current UI state.
+- Use ui_context for current selection/playhead/highlighted notes only when the user references "this"/"current" context.
+- If a song/tool lookup succeeded, ground your answer in those results.
+- Do NOT say you lack direct tab database access. You are integrated with a song-tab lookup tool.
 """
 
-ANSWER_METADATA_INSTRUCTIONS = """Given this guitar/music question and answer, extract structured metadata. Return ONLY the requested fields.
+ANSWER_POSTPROCESS_INSTRUCTIONS = """Given a guitar/music question and answer, extract structured metadata AND fretboard highlight positions in a single response.
 
 Question: {user_question}
 Answer: {answer}
+UI context: {ui_context}
+Tuning (string 1=high E to string 6=low E): {tuning_notes}
 
+--- PART 1: Metadata ---
 Extract:
-- scale: the single most relevant scale name (e.g., "A minor pentatonic")
+- scale: the single most relevant scale name (e.g., "A minor pentatonic"), or null
 - chord_choices: list of chord names mentioned or recommended (e.g., ["C", "Am", "F", "G"])
 - visualizations: true if the answer involves chords, scales, progressions, song tabs, or measure navigation
+
+--- PART 2: Fretboard highlights ---
+Extract highlight_groups: fret positions to highlight on the interactive fretboard.
+
+When to emit groups:
+- Emit groups when the answer discusses SPECIFIC fret positions, voicings, shapes, or fingerings. This includes:
+  - Explicit string/fret references (e.g. "3rd fret on the A string")
+  - Tab-notation voicings (e.g. "x32010", "3x2003") — convert these to string/fret positions (leftmost digit = string 6/low E, rightmost = string 1/high E; "x" = muted/skip, "0" = open)
+  - Named shapes with positions (e.g. "CAGED shape at fret 5", "barre chord at 7th fret")
+- Do NOT emit groups for general theory, chord names without ANY position info, or scale names without specific fret references.
+
+Group rules:
+- Each group is one named shape/voicing/position set. Multiple groups = multiple alternatives to cycle through.
+- String numbering: string 1 = high E (thinnest), string 6 = low E (thickest). Fret 0 = open string.
+- Keep group names short (2-5 words), e.g. "Open E", "Barre at 5th", "Box 1", "CAGED A shape".
+- Omit muted/unplayed strings — only include strings that are actually fretted or open and part of the shape.
+- Max 6 groups. Max 6 positions per group.
+
+Playability constraints (CRITICAL — every voicing MUST be physically playable):
+- Max 4-fret span between the lowest and highest fretted notes (excluding open strings). Stretch up to 5 frets ONLY for intentionally creative/extended voicings.
+- At most one note per string.
+- All fretted notes must be reachable simultaneously by a human fretting hand — no impossible finger stretches.
+- Prefer standard voicing positions (open chords, common barre shapes, CAGED forms) unless the user specifically asks for unusual or creative voicings.
+- When suggesting chord progressions, use voicings in nearby positions to minimize hand movement between chords.
+
+Return empty list if no specific fret positions apply.
 """
 
 SUMMARY_INSTRUCTIONS = """Summarize the conversation for future guitar tutoring context.
@@ -166,9 +235,8 @@ Return a concise summary under 180 words capturing:
 
 # Node names for status tracking
 _NODE_FIELDS = {
-    "question_for_llm": "prepare_question",
     "answer": "generate_answer",
-    "clarifying_question": "prepare_question",
+    "clarifying_question_for_user": "prepare_question",
 }
 
 
@@ -204,6 +272,8 @@ class GuitarTutorAgent:
         llm_kwargs: dict = {"model": model_name, "temperature": temperature, "api_key": resolved_key}
         if base_url:
             llm_kwargs["base_url"] = base_url
+        if settings.llm_timeout_seconds and settings.llm_timeout_seconds > 0:
+            llm_kwargs["timeout"] = settings.llm_timeout_seconds
 
         self.llm = ChatOpenAI(**llm_kwargs)
         self.graph = self._build_graph()
@@ -256,14 +326,10 @@ class GuitarTutorAgent:
         last_question_text = self._message_text(messages[-1]) if messages else ""
         lower_question = last_question_text.lower().strip()
 
-        # Deterministic fast-path: when UI context is strong for deictic chord-identification,
-        # avoid unnecessary clarification loops and carry concrete beat context forward.
+        # Deterministic fast-path: deictic chord-identification with strong UI context
         if self._is_context_identification_question(lower_question) and self._has_strong_ui_context(ui_context):
-            selected_beat = ui_context.get("selected_beat_id")
-            beat_text = f" at selected beat {selected_beat}" if selected_beat else ""
             return {
-                "question_for_llm": f"Identify the chord{beat_text} using highlighted notes in current song context.",
-                "clarifying_question": None,
+                "clarifying_question_for_user": None,
                 "out_of_scope": False,
                 "running_summary": running_summary,
                 "summary_turn_count": summary_turn_count,
@@ -281,32 +347,31 @@ class GuitarTutorAgent:
         q = self._invoke_structured(
             PreppedQuestionSchema,
             [system_message],
-            fallback={"question_for_llm": last_question_text, "out_of_scope": False},
+            fallback={"out_of_scope": False},
         )
 
         logger.info("Prepared question=%s", q)
 
-        clarifying_question = q.get("clarifying_question")
-        if isinstance(clarifying_question, str) and clarifying_question.strip().lower() in {"null", "none"}:
-            clarifying_question = None
+        clarifying_question_for_user = q.get("clarifying_question_for_user")
+        if isinstance(clarifying_question_for_user, str) and clarifying_question_for_user.strip().lower() in {"null", "none"}:
+            clarifying_question_for_user = None
 
         return {
-            "question_for_llm": q.get("question_for_llm"),
-            "clarifying_question": clarifying_question,
+            "clarifying_question_for_user": clarifying_question_for_user,
             "out_of_scope": q.get("out_of_scope", False),
             "running_summary": running_summary,
             "summary_turn_count": summary_turn_count,
         }
 
     def _clarify_input(self, state: dict) -> Command:
-        clarifying_question = state.get("clarifying_question")
+        clarifying_question_for_user = state.get("clarifying_question_for_user")
 
-        if not clarifying_question:
+        if not clarifying_question_for_user:
             return Command(goto="generate_answer")
 
         human_input = interrupt(
             {
-                "clarifying_question": clarifying_question,
+                "clarifying_question": clarifying_question_for_user,
                 "action": "Please answer this question to continue",
             }
         )
@@ -314,14 +379,14 @@ class GuitarTutorAgent:
         return Command(
             update={
                 "messages": [HumanMessage(content=human_input.get("response", ""))],
-                "clarifying_question": None,
+                "clarifying_question_for_user": None,
+                "out_of_scope": False,
             },
-            goto="prepare_question",
+            goto="generate_answer",
         )
 
     def _generate_answer(self, state: dict) -> dict:
-        question_for_llm = state.get("question_for_llm")
-        clarifying_question = state.get("clarifying_question")
+        clarifying_question_for_user = state.get("clarifying_question_for_user")
         out_of_scope = state.get("out_of_scope", False)
         running_summary = state.get("running_summary", "")
         ui_context = state.get("ui_context") or {}
@@ -343,10 +408,10 @@ class GuitarTutorAgent:
                 "memory_status": memory_status,
             }
 
-        if clarifying_question and not question_for_llm:
+        if clarifying_question_for_user:
             return {
-                "messages": [AIMessage(content=clarifying_question)],
-                "answer": clarifying_question,
+                "messages": [AIMessage(content=clarifying_question_for_user)],
+                "answer": clarifying_question_for_user,
                 "scale": None,
                 "chord_choices": [],
                 "visualizations": False,
@@ -356,48 +421,75 @@ class GuitarTutorAgent:
             }
 
         messages = state.get("messages", [])
-        question_text = question_for_llm if question_for_llm else (self._message_text(messages[-1]) if messages else "")
-
-        tool_context, song_actions = self._run_song_tools(question_text, ui_context)
+        user_question = self._message_text(messages[-1]) if messages else ""
         prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
+        song_tool_plan = self._plan_song_tools(
+            user_question=user_question,
+            messages=messages,
+            ui_context=ui_context,
+            running_summary=running_summary,
+        )
+        logger.info("Song tool plan=%s", song_tool_plan)
+        tool_context, song_actions = self._run_song_tools(
+            user_question,
+            ui_context,
+            song_search_query=song_tool_plan.get("song_search_query"),
+            focus_measure_number=song_tool_plan.get("focus_measure_number"),
+        )
 
         # Call 1: Generate answer text (regular LLM — streamed via stream_mode="messages")
         text_system = SystemMessage(
             content=ANSWER_TEXT_INSTRUCTIONS.format(
-                user_question=question_text,
                 running_summary=running_summary or "None",
                 ui_context=prompt_ui_context or "None",
                 tool_context=tool_context or "None",
             )
         )
-        response = self.llm.invoke([text_system, HumanMessage(content=question_text)])
-        answer_text = self._coerce_text(response.content)
 
-        # Call 2: Extract metadata (structured output — quick, not streamed)
-        metadata_system = SystemMessage(
-            content=ANSWER_METADATA_INSTRUCTIONS.format(
-                user_question=question_text,
+        # Include recent conversation history so the LLM can resolve
+        # follow-up references ("this", "those chords", "show me visualizations for that")
+        recent_history = messages[-(self.recent_turn_window * 2):]
+        llm_messages = [text_system] + recent_history
+        response = self.llm.invoke(llm_messages)
+        answer_text = self._clean_answer_text(self._coerce_text(response.content))
+
+        # Call 2: Extract metadata + fretboard highlights in one structured call
+        tuning_id = ui_context.get("selected_tuning") or "standard"
+        custom_notes = ui_context.get("custom_tuning_notes")
+        tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
+
+        postprocess_system = SystemMessage(
+            content=ANSWER_POSTPROCESS_INSTRUCTIONS.format(
+                user_question=user_question,
                 answer=answer_text,
+                ui_context=prompt_ui_context or "None",
+                tuning_notes=tuning_notes,
             )
         )
-        meta = self._invoke_structured(
-            AnswerMetadataSchema,
-            [metadata_system],
-            fallback={"scale": None, "chord_choices": [], "visualizations": False},
+        post = self._invoke_structured(
+            AnswerPostProcessSchema,
+            [postprocess_system],
+            fallback={"scale": None, "chord_choices": [], "visualizations": False, "highlight_groups": []},
         )
 
         actions: list[dict] = []
         if self.actions_enabled:
             actions.extend(song_actions)
-            actions.extend(self._build_theory_actions(meta.get("scale"), meta.get("chord_choices", [])))
+            actions.extend(self._build_theory_actions(post.get("scale"), post.get("chord_choices", [])))
+
+            # Validate and add highlight groups from the combined call
+            highlight_groups = self._validate_highlight_groups(post.get("highlight_groups", []))
+            if highlight_groups:
+                actions.append({"type": "fretboard.highlight", "groups": highlight_groups})
+
             actions = self._dedupe_actions(actions)
 
         return {
             "messages": [AIMessage(content=answer_text)],
             "answer": answer_text,
-            "scale": meta.get("scale"),
-            "chord_choices": meta.get("chord_choices", []),
-            "visualizations": meta.get("visualizations", False),
+            "scale": post.get("scale"),
+            "chord_choices": post.get("chord_choices", []),
+            "visualizations": post.get("visualizations", False),
             "out_of_scope": False,
             "actions": actions,
             "memory_status": memory_status,
@@ -406,19 +498,76 @@ class GuitarTutorAgent:
     # --- Shared helpers ---
 
     def _invoke_structured(self, schema, messages: list, *, fallback: dict) -> dict:
-        """Invoke structured output with error handling and fallback."""
+        """Invoke structured output with error handling and fallback.
+
+        Tries with_structured_output first (native tool/function calling).
+        If that fails, falls back to a plain LLM call and parses JSON from the response text.
+        """
+        schema_name = getattr(schema, "__name__", str(schema))
+
+        # Attempt 1: native structured output
         try:
             structured_llm = self.llm.with_structured_output(schema)
             result = structured_llm.invoke(messages)
             if result is None:
-                logger.warning("Structured output returned None, using fallback")
-                return fallback
-            return result if isinstance(result, dict) else (
-                result.model_dump() if hasattr(result, "model_dump") else result.dict()
-            )
+                logger.warning("Structured output returned None, trying JSON fallback")
+            else:
+                return result if isinstance(result, dict) else (
+                    result.model_dump() if hasattr(result, "model_dump") else result.dict()
+                )
         except Exception as e:
-            logger.error("Structured output failed (%s): %s", getattr(schema, "__name__", str(schema)), e)
-            return fallback
+            logger.warning("Structured output failed (%s): %s — trying JSON fallback", schema_name, e)
+
+        # Attempt 2: plain call + JSON extraction
+        try:
+            raw_response = self.llm.invoke(messages)
+            raw_text = self._coerce_text(raw_response.content).strip()
+            parsed = self._extract_json(raw_text)
+            if parsed is not None:
+                logger.info("JSON fallback succeeded for %s", schema_name)
+                return parsed
+            logger.warning("JSON fallback could not parse response for %s", schema_name)
+        except Exception as e:
+            logger.error("JSON fallback also failed (%s): %s", schema_name, e)
+
+        return fallback
+
+    @staticmethod
+    def _extract_json(text: str) -> dict | None:
+        """Extract a JSON object from LLM text that may contain markdown fences or preamble."""
+        import json
+
+        # Try the whole string first
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+
+        # Try extracting from markdown code fences
+        fence_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+        if fence_match:
+            try:
+                return json.loads(fence_match.group(1).strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Try finding the first { ... } block
+        brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+        if brace_match:
+            try:
+                return json.loads(brace_match.group(0))
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
+    @staticmethod
+    def _clean_answer_text(text: str) -> str:
+        """Strip model-specific artifacts (e.g. minimax tool_call blocks) from answer text."""
+        cleaned = re.sub(r"<minimax:tool_call>.*?</minimax:tool_call>", "", text, flags=re.DOTALL)
+        # Also handle unclosed tags
+        cleaned = re.sub(r"<minimax:tool_call>.*", "", cleaned, flags=re.DOTALL)
+        return cleaned.strip()
 
     @staticmethod
     def _coerce_text(content: Any) -> str:
@@ -531,6 +680,70 @@ class GuitarTutorAgent:
                 return node
         return "processing"
 
+    @staticmethod
+    def _validate_highlight_groups(groups: list) -> list[dict]:
+        """Validate and filter highlight groups from structured output."""
+        valid_groups = []
+        for g in (groups or []):
+            name = g.get("name", "").strip()
+            positions = [
+                p for p in (g.get("positions") or [])
+                if isinstance(p.get("string"), int) and isinstance(p.get("fret"), int)
+                and 1 <= p["string"] <= 6 and 0 <= p["fret"] <= 22
+            ]
+            if name and positions:
+                valid_groups.append({"name": name, "positions": positions})
+        return valid_groups
+
+    def _plan_song_tools(
+        self,
+        *,
+        user_question: str,
+        messages: list,
+        ui_context: dict,
+        running_summary: str,
+    ) -> dict:
+        """Use the answer-phase model to decide if song tools are needed."""
+        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
+        recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
+        previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
+
+        system_message = SystemMessage(
+            content=SONG_TOOL_INTENT_INSTRUCTIONS.format(
+                running_summary=running_summary or "None",
+                previous_context=previous_context,
+                ui_context=prompt_ui_context or "None",
+                user_question=user_question,
+            )
+        )
+
+        plan = self._invoke_structured(
+            SongToolPlanSchema,
+            [system_message],
+            fallback={"song_search_query": None, "focus_measure_number": None},
+        )
+
+        song_search_query = plan.get("song_search_query")
+        if isinstance(song_search_query, str):
+            song_search_query = song_search_query.strip()
+            if song_search_query.lower() in {"", "null", "none"}:
+                song_search_query = None
+        else:
+            song_search_query = None
+
+        focus_measure_number = plan.get("focus_measure_number")
+        try:
+            focus_measure_number = int(focus_measure_number) if focus_measure_number is not None else None
+        except (TypeError, ValueError):
+            focus_measure_number = None
+        if focus_measure_number is not None and focus_measure_number < 1:
+            focus_measure_number = None
+
+        return {
+            "song_search_query": song_search_query,
+            "focus_measure_number": focus_measure_number,
+        }
+
     def _build_theory_actions(self, scale: Optional[str], chord_choices: List[str]) -> list[dict]:
         actions: list[dict] = []
 
@@ -573,21 +786,23 @@ class GuitarTutorAgent:
             deduped.append(action)
         return deduped
 
-    def _run_song_tools(self, question_text: str, ui_context: dict) -> tuple[str, list[dict]]:
+    def _run_song_tools(
+        self,
+        question_text: str,
+        ui_context: dict,
+        *,
+        song_search_query: str | None = None,
+        focus_measure_number: int | None = None,
+    ) -> tuple[str, list[dict]]:
         """Run bounded Songsterr lookups for song/measure intents and return context + actions."""
         if not self.tool_calling_enabled:
             return "", []
 
         q = question_text.strip()
         lower_q = q.lower()
-        search_query = self._extract_song_search_query(q)
-        song_intent = (
-            any(token in lower_q for token in ["song", "tab", "track", "measure", "riff", "verse", "chorus"])
-            or search_query is not None
-            or ("display" in lower_q and ("song" in lower_q or "tab" in lower_q))
-        )
-        if not song_intent:
-            return "", []
+        search_query = song_search_query.strip() if isinstance(song_search_query, str) else None
+        if search_query and search_query.lower() in {"null", "none"}:
+            search_query = None
 
         tool_context_lines: list[str] = []
         actions: list[dict] = []
@@ -623,11 +838,7 @@ class GuitarTutorAgent:
                 tool_context_lines.append(f"Song search failed for '{search_query}': {exc}")
 
         # 2) Measure focus intent (for this song or selected search result)
-        requested_measure = self._extract_measure_index(q)
-        wants_measure_focus = (
-            (requested_measure is not None and self._is_measure_navigation_intent(lower_q))
-            or self._is_explicit_measure_navigation(lower_q)
-        )
+        focus_measure_index = focus_measure_number - 1 if isinstance(focus_measure_number, int) else None
 
         # For deictic identification questions ("what chord is this"), trust selected UI beat context
         # and avoid expensive network measure resolution.
@@ -638,15 +849,14 @@ class GuitarTutorAgent:
                 tool_context_lines.append(
                     f"User selected beat context: beat_id={selected_beat}, highlighted_frets={highlighted}."
                 )
-            wants_measure_focus = False
+            focus_measure_index = None
 
-        if wants_measure_focus and selected_song_id is not None:
-            measure_index = requested_measure if requested_measure is not None else int((ui_context or {}).get("playhead_measure_index") or 0)
+        if focus_measure_index is not None and selected_song_id is not None:
             try:
                 resolved_measure, resolved_beat = songsterr.resolve_measure_focus_sync(
                     song_id=int(selected_song_id),
                     track_index=selected_track_index,
-                    requested_measure_index=max(0, measure_index),
+                    requested_measure_index=max(0, focus_measure_index),
                 )
                 action: dict[str, Any] = {
                     "type": "song.measure.focus",
@@ -664,6 +874,10 @@ class GuitarTutorAgent:
                     f"Could not resolve measure focus for song_id={selected_song_id}, "
                     f"track={selected_track_index}: {exc}"
                 )
+        elif focus_measure_index is not None:
+            tool_context_lines.append(
+                f"User asked to focus measure {focus_measure_number}, but no song is currently selected."
+            )
 
         return "\n".join(tool_context_lines), self._dedupe_actions(actions)
 
@@ -715,45 +929,6 @@ class GuitarTutorAgent:
             projected["highlighted_notes"] = resolved
 
         return projected
-
-    @staticmethod
-    def _extract_song_search_query(question: str) -> Optional[str]:
-        text = question.strip()
-        lower = text.lower()
-
-        # Handle common "tabs for <song>" phrasing regardless of sentence prefix.
-        generic_for_match = re.search(
-            r"\b(?:tab|tabs|song|songs|track|tracks)\s+for\s+(.+)",
-            lower,
-        )
-        if generic_for_match:
-            query = generic_for_match.group(1).strip(" .,!?:;")
-            if query and "measure" not in query:
-                return query
-
-        patterns = [
-            r"(?:search|find|look\s*up|display|show)\s+(?:for\s+)?(?:song|songs|tab|tabs|track|tracks)\s+(.+)",
-            r"(?:show|display)\s+(?:me\s+)?(?:the\s+)?tab\s+for\s+(.+)",
-            r"look\s+up\s+(.+)",
-        ]
-        for pattern in patterns:
-            match = re.match(pattern, lower)
-            if not match:
-                continue
-            query = match.group(1).strip(" .,!?")
-            if query and len(query) >= 2:
-                return query
-
-        # Quoted title fallback: "Frisky" by Dominic Fike
-        quote_match = re.search(r'"([^"]+)"(?:\s+by\s+([a-z0-9 .,&\'-]+))?', lower)
-        if quote_match:
-            title = quote_match.group(1).strip(" .,!?:;")
-            artist = (quote_match.group(2) or "").strip(" .,!?:;")
-            if title and artist:
-                return f"{title} {artist}"
-            if title:
-                return title
-        return None
 
     @staticmethod
     def _normalize_search_text(text: str) -> str:
@@ -817,16 +992,6 @@ class GuitarTutorAgent:
         return best_record, best_score
 
     @staticmethod
-    def _extract_measure_index(question: str) -> Optional[int]:
-        match = re.search(r"\bmeasure\s*#?\s*(\d+)\b", question.lower())
-        if not match:
-            return None
-
-        # Users speak in 1-based measure numbers; action contract is 0-based.
-        one_based = int(match.group(1))
-        return max(0, one_based - 1)
-
-    @staticmethod
     def _is_context_identification_question(lower_question: str) -> bool:
         return any(
             phrase in lower_question
@@ -850,32 +1015,6 @@ class GuitarTutorAgent:
             ui_context.get("playhead_measure_index") is not None
         )
         return (has_selected_beat or has_song_or_playhead) and has_highlighted
-
-    @staticmethod
-    def _is_measure_navigation_intent(lower_question: str) -> bool:
-        return any(
-            token in lower_question
-            for token in [
-                "go to",
-                "jump to",
-                "navigate to",
-                "move to",
-                "focus",
-                "show me",
-                "display",
-                "scroll to",
-                "play from",
-                "start at",
-            ]
-        )
-
-    @staticmethod
-    def _is_explicit_measure_navigation(lower_question: str) -> bool:
-        patterns = [
-            r"\b(?:go|jump|move|navigate|scroll|start|play)\s+.*\bmeasure\b",
-            r"\bmeasure\s+\d+\s*(?:please|now|next)?\b",
-        ]
-        return any(re.search(pattern, lower_question) for pattern in patterns)
 
     def _maybe_refresh_summary(self, state: dict) -> tuple[str, int]:
         """Maintain a rolling summary for long threads (logical compaction)."""

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -1,14 +1,16 @@
 """
 Guitar Tutor LangGraph Agent.
-Provides music theory and guitar-related answers using a three-node graph:
+
+Graph nodes:
 1. prepare_question - normalizes and validates the user's question
 2. clarify_input - handles interrupt/resume for clarifying questions
-3. generate_answer - generates a structured answer with chord/scale recommendations
+3. generate_answer - generates answer text + structured metadata/actions
 """
 
 import logging
 import os
-from typing import Generator, List, Optional, TypedDict
+import re
+from typing import Any, Generator, List, Optional, TypedDict
 
 from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -18,15 +20,31 @@ from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
 from pydantic import Field
 
+from app.agent.parser import parse_chord_name, parse_scale_name
+from app.config import get_settings
+from app.models.songsterr import SongsterrRecord
+from app.music.notes import get_note_at_fret
+from app.music.tunings import get_tuning_notes
+from app.services import songsterr
+
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+
+class ThreadNotFoundError(RuntimeError):
+    """Raised when a requested thread_id does not exist in checkpoint storage."""
+
+    def __init__(self, thread_id: str):
+        super().__init__(f"THREAD_NOT_FOUND: thread '{thread_id}' has no persisted state")
+        self.thread_id = thread_id
 
 
 # --- Structured output schemas ---
 
 class PreppedQuestionSchema(TypedDict):
     """Schema for the prepare_question node output."""
+
     question_for_llm: Optional[str] = Field(None, description="A concise guitar/music-theory question")
     out_of_scope: bool = Field(False, description="Whether the question is out of scope")
     clarifying_question: Optional[str] = Field(None, description="A clarifying question if needed")
@@ -34,13 +52,15 @@ class PreppedQuestionSchema(TypedDict):
 
 class AnswerMetadataSchema(TypedDict):
     """Schema for answer metadata extraction (scale, chords, visualizations)."""
-    scale: str = Field(..., description="A single recommended scale name relevant to the user question")
-    chord_choices: List[str] = Field(..., description="List of chord names recommended")
+
+    scale: Optional[str] = Field(None, description="Most relevant scale name")
+    chord_choices: List[str] = Field(default_factory=list, description="List of chord names recommended")
     visualizations: bool = Field(False, description="Whether visualizations are needed")
 
 
 class OverallState(MessagesState):
     """Overall state for the agent graph."""
+
     question_for_llm: Optional[str] = None
     clarifying_question: Optional[str] = None
     answer: str = ""
@@ -49,17 +69,30 @@ class OverallState(MessagesState):
     visualizations: bool = False
     out_of_scope: bool = False
 
+    # New context/memory fields
+    ui_context: dict = {}
+    running_summary: str = ""
+    summary_turn_count: int = 0
+
+    # New response fields
+    actions: List[dict] = []
+    memory_status: str = "fresh"
+
 
 # --- Prompt templates ---
 
 PREP_QUESTION_INSTRUCTIONS = """You are the Guitar Tutor question normalizer. You will ONLY prepare a single, concise MUSIC THEORY / GUITAR question for the NEXT node to answer — do NOT answer the question yourself.
 
-Inputs available to you (replace in runtime): {previous_context} (list of recent messages, most recent last) and {user_question} (string).
+Inputs available to you (replace in runtime):
+- running_summary: {running_summary}
+- previous_context: {previous_context}
+- ui_context: {ui_context}
+- user_question: {user_question}
 
-Output requirements (JSON ONLY): produce exactly one of these three JSON shapes and nothing else. Use canonical chord/scale names when relevant. Keep output ≤ 20 words when possible.
+Output requirements (JSON ONLY): produce exactly one of these three JSON shapes and nothing else. Use canonical chord/scale names when relevant. Keep output <= 20 words when possible.
 
 1) Clear music/guitar question — STRONGLY PREFERRED. Use your best judgment to fill in any gaps.
-{{"question_for_llm": "<≤ 20 words, concise guitar/music-theory question>", "out_of_scope": false}}
+{{"question_for_llm": "<<= 20 words, concise guitar/music-theory question>", "out_of_scope": false}}
 
 2) Need clarification — LAST RESORT ONLY. Use this ONLY when you truly cannot proceed (e.g., the question is so vague that any assumption would be misleading).
 {{"clarifying_question": "<one short clarifying question>", "out_of_scope": false}}
@@ -68,30 +101,42 @@ Output requirements (JSON ONLY): produce exactly one of these three JSON shapes 
 {{"out_of_scope": true}}
 
 Best judgment guidelines:
-- PREFER producing a question_for_llm over asking for clarification. Make reasonable assumptions and move forward.
-- If the user omits a key (e.g., "what scale should I use for blues?"), pick the most common one (e.g., A or E for blues) and note your assumption in the question, like: "What scale to use for blues in A? (assumed A — adjust if needed)"
-- If the user omits details like tuning, assume standard tuning. If they omit a genre, infer from context.
+- PREFER producing question_for_llm over asking for clarification. Make reasonable assumptions and move forward.
+- Treat ui_context as a trusted runtime source of truth for current app/song/beat state whenever available.
+- If details are missing in user text but present in ui_context, use ui_context and continue instead of asking clarification.
+- If the user omits details like tuning, assume standard tuning unless ui_context indicates otherwise.
+- If ui_context has active song/track state and user asks about "this song", keep that context.
+- If user asks deictic questions like "What chord is this?" and ui_context includes selected_beat_id/highlighted_notes, keep that selected-beat context explicit.
+- Do not invent or renumber measure/beat references if selected_beat_id already provides concrete context.
+- If the user asks to search/find/show/display a song or tab, preserve that intent explicitly in question_for_llm (e.g., include artist/title clue).
+- If the user asks to show a section or measure, preserve the requested measure reference in question_for_llm.
 - Only use clarifying_question when the request is genuinely too vague to make ANY reasonable assumption.
-- If the user's request is not music, guitar or music theory related, return the out_of_scope JSON above.
-- If you provide a clarifying_question, do not provide a question_for_llm as well.
-- IMPORTANT: If you produce a clarifying question, it MUST be returned in the `clarifying_question` field and `question_for_llm` MUST be empty or null.
-- Prefer concise canonical names for chords/scales (e.g., "C major", "A minor pentatonic").
+- If the user's request is not music, guitar, songs, tabs, measures, or music theory related, return out_of_scope true.
+- If you provide clarifying_question, do not provide question_for_llm.
 - Do NOT include voicings, diagrams, notes, or additional metadata.
 """
 
 ANSWER_TEXT_INSTRUCTIONS = """You are the Guitar Tutor. Answer the user's guitar/music theory question.
 
 Hard constraints:
-- ONLY answer music theory or guitar-related questions.
-- Mention relevant chords and scales by name (e.g., "C major", "A minor pentatonic").
+- ONLY answer music theory, guitar, songs, tabs, and measure-navigation related questions.
 - Keep output concise: 1-3 paragraphs.
 
-Tone & pedagogy:
-- Be friendly, clear, and pedagogical. Explain WHY choices work.
-- Use short examples where helpful.
-- If the question contains an assumption note (e.g., "assumed A — adjust if needed"), briefly mention it at the end of your answer in a natural way, like: "I went with A here — feel free to ask about a different key!" Keep it short and conversational, not a disclaimer.
+Inputs:
+- Question: {user_question}
+- Running summary: {running_summary}
+- UI context: {ui_context}
+- Tool context: {tool_context}
 
-Question: {user_question}
+Behavior:
+- Be clear and pedagogical. Explain WHY choices work.
+- Treat ui_context as authoritative for current selection/playhead/highlighted notes when present.
+- If a concrete song/tool lookup succeeded, ground your answer in those results.
+- If a lookup failed, explain the limitation briefly and continue with the best fallback guidance.
+- If user intent is song search/display, briefly name the matched song/artist (if known) and what the UI will show next.
+- If user intent is measure/section focus, explicitly mention the measure target and any assumptions made.
+- Do NOT say you lack direct tab database access. You are integrated with a song-tab lookup tool in this application.
+- For deictic questions ("this chord", "this beat"), prioritize ui_context.selected_beat_id/highlighted_notes as the reference.
 """
 
 ANSWER_METADATA_INSTRUCTIONS = """Given this guitar/music question and answer, extract structured metadata. Return ONLY the requested fields.
@@ -102,7 +147,21 @@ Answer: {answer}
 Extract:
 - scale: the single most relevant scale name (e.g., "A minor pentatonic")
 - chord_choices: list of chord names mentioned or recommended (e.g., ["C", "Am", "F", "G"])
-- visualizations: true if the answer involves chords, scales, or progressions that can be shown on a fretboard
+- visualizations: true if the answer involves chords, scales, progressions, song tabs, or measure navigation
+"""
+
+SUMMARY_INSTRUCTIONS = """Summarize the conversation for future guitar tutoring context.
+
+Current running summary:
+{running_summary}
+
+Older raw messages to compress:
+{older_messages}
+
+Return a concise summary under 180 words capturing:
+- User goals/preferences
+- Musical key/tuning/song context
+- Prior recommendations and constraints
 """
 
 # Node names for status tracking
@@ -116,10 +175,27 @@ _NODE_FIELDS = {
 class GuitarTutorAgent:
     """Guitar Tutor Agent using LangGraph."""
 
-    def __init__(self, model_name: str = "gpt-4o-mini", temperature: float = 0,
-                 base_url: str | None = None, api_key: str | None = None):
-        self.memory = MemorySaver()
+    def __init__(
+        self,
+        model_name: str = "gpt-4o-mini",
+        temperature: float = 0,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ):
+        settings = get_settings()
+        self._sqlite_conn = None
+        self.memory = self._build_checkpointer(
+            backend=settings.agent_checkpoint_backend,
+            sqlite_path=settings.agent_checkpoint_sqlite_path,
+        )
         self.model_name = model_name
+
+        self.actions_enabled = settings.agent_actions_enabled
+        self.tool_calling_enabled = settings.agent_tool_calling_enabled
+        self.summary_enabled = settings.agent_summary_enabled
+        self.summary_turn_interval = max(1, settings.agent_summary_turn_interval)
+        self.summary_char_threshold = max(1000, settings.agent_summary_char_threshold)
+        self.recent_turn_window = max(2, settings.agent_recent_turn_window)
 
         resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not resolved_key:
@@ -131,6 +207,25 @@ class GuitarTutorAgent:
 
         self.llm = ChatOpenAI(**llm_kwargs)
         self.graph = self._build_graph()
+
+    def _build_checkpointer(self, *, backend: str, sqlite_path: str):
+        backend_normalized = (backend or "memory").strip().lower()
+        if backend_normalized != "sqlite":
+            return MemorySaver()
+
+        try:
+            import sqlite3
+            from pathlib import Path
+            from langgraph.checkpoint.sqlite import SqliteSaver
+
+            db_path = Path(sqlite_path).expanduser().resolve()
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._sqlite_conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            logger.info("Using SQLite checkpoint backend at %s", db_path)
+            return SqliteSaver(self._sqlite_conn)
+        except Exception as exc:
+            logger.warning("Falling back to in-memory checkpoints (SQLite unavailable): %s", exc)
+            return MemorySaver()
 
     # --- Graph construction ---
 
@@ -151,30 +246,56 @@ class GuitarTutorAgent:
 
     def _prepare_question(self, state: dict) -> dict:
         messages = state.get("messages", [])
-        recent_messages = messages[-4:] if len(messages) > 4 else messages
-        previous_context = (
-            "\n".join([msg.content for msg in recent_messages[:-1]])
-            if len(recent_messages) > 1
-            else "None"
-        )
-        last_question_text = messages[-1].content if messages else ""
+        ui_context = state.get("ui_context") or {}
+        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
+
+        running_summary, summary_turn_count = self._maybe_refresh_summary(state)
+
+        recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
+        previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
+        last_question_text = self._message_text(messages[-1]) if messages else ""
+        lower_question = last_question_text.lower().strip()
+
+        # Deterministic fast-path: when UI context is strong for deictic chord-identification,
+        # avoid unnecessary clarification loops and carry concrete beat context forward.
+        if self._is_context_identification_question(lower_question) and self._has_strong_ui_context(ui_context):
+            selected_beat = ui_context.get("selected_beat_id")
+            beat_text = f" at selected beat {selected_beat}" if selected_beat else ""
+            return {
+                "question_for_llm": f"Identify the chord{beat_text} using highlighted notes in current song context.",
+                "clarifying_question": None,
+                "out_of_scope": False,
+                "running_summary": running_summary,
+                "summary_turn_count": summary_turn_count,
+            }
 
         system_message = SystemMessage(
             content=PREP_QUESTION_INSTRUCTIONS.format(
+                running_summary=running_summary or "None",
                 previous_context=previous_context,
+                ui_context=prompt_ui_context or "None",
                 user_question=last_question_text,
             )
         )
 
-        q = self._invoke_structured(PreppedQuestionSchema, [system_message],
-                                    fallback={"question_for_llm": last_question_text, "out_of_scope": False})
+        q = self._invoke_structured(
+            PreppedQuestionSchema,
+            [system_message],
+            fallback={"question_for_llm": last_question_text, "out_of_scope": False},
+        )
 
-        logger.info(f"Prepared question: {q}")
+        logger.info("Prepared question=%s", q)
+
+        clarifying_question = q.get("clarifying_question")
+        if isinstance(clarifying_question, str) and clarifying_question.strip().lower() in {"null", "none"}:
+            clarifying_question = None
 
         return {
             "question_for_llm": q.get("question_for_llm"),
-            "clarifying_question": q.get("clarifying_question"),
+            "clarifying_question": clarifying_question,
             "out_of_scope": q.get("out_of_scope", False),
+            "running_summary": running_summary,
+            "summary_turn_count": summary_turn_count,
         }
 
     def _clarify_input(self, state: dict) -> Command:
@@ -183,10 +304,12 @@ class GuitarTutorAgent:
         if not clarifying_question:
             return Command(goto="generate_answer")
 
-        human_input = interrupt({
-            "clarifying_question": clarifying_question,
-            "action": "Please answer this question to continue",
-        })
+        human_input = interrupt(
+            {
+                "clarifying_question": clarifying_question,
+                "action": "Please answer this question to continue",
+            }
+        )
 
         return Command(
             update={
@@ -200,9 +323,15 @@ class GuitarTutorAgent:
         question_for_llm = state.get("question_for_llm")
         clarifying_question = state.get("clarifying_question")
         out_of_scope = state.get("out_of_scope", False)
+        running_summary = state.get("running_summary", "")
+        ui_context = state.get("ui_context") or {}
+        memory_status = state.get("memory_status", "fresh")
 
         if out_of_scope:
-            refusal_msg = "I only help with guitar & music theory — please ask about chords, scales, fretboard shapes, voicings, or music theory concepts."
+            refusal_msg = (
+                "I only help with guitar, songs/tabs, measures, and music theory. "
+                "Ask about chords, scales, fretboard shapes, progressions, songs, or tab sections."
+            )
             return {
                 "messages": [AIMessage(content=refusal_msg)],
                 "answer": refusal_msg,
@@ -210,6 +339,8 @@ class GuitarTutorAgent:
                 "chord_choices": [],
                 "visualizations": False,
                 "out_of_scope": True,
+                "actions": [],
+                "memory_status": memory_status,
             }
 
         if clarifying_question and not question_for_llm:
@@ -220,28 +351,46 @@ class GuitarTutorAgent:
                 "chord_choices": [],
                 "visualizations": False,
                 "out_of_scope": False,
+                "actions": [],
+                "memory_status": memory_status,
             }
 
         messages = state.get("messages", [])
-        question_text = question_for_llm if question_for_llm else (
-            messages[-1].content if messages else ""
-        )
+        question_text = question_for_llm if question_for_llm else (self._message_text(messages[-1]) if messages else "")
+
+        tool_context, song_actions = self._run_song_tools(question_text, ui_context)
+        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
 
         # Call 1: Generate answer text (regular LLM — streamed via stream_mode="messages")
         text_system = SystemMessage(
-            content=ANSWER_TEXT_INSTRUCTIONS.format(user_question=question_text)
+            content=ANSWER_TEXT_INSTRUCTIONS.format(
+                user_question=question_text,
+                running_summary=running_summary or "None",
+                ui_context=prompt_ui_context or "None",
+                tool_context=tool_context or "None",
+            )
         )
         response = self.llm.invoke([text_system, HumanMessage(content=question_text)])
-        answer_text = response.content
+        answer_text = self._coerce_text(response.content)
 
         # Call 2: Extract metadata (structured output — quick, not streamed)
         metadata_system = SystemMessage(
             content=ANSWER_METADATA_INSTRUCTIONS.format(
-                user_question=question_text, answer=answer_text
+                user_question=question_text,
+                answer=answer_text,
             )
         )
-        meta = self._invoke_structured(AnswerMetadataSchema, [metadata_system],
-                                       fallback={"scale": None, "chord_choices": [], "visualizations": False})
+        meta = self._invoke_structured(
+            AnswerMetadataSchema,
+            [metadata_system],
+            fallback={"scale": None, "chord_choices": [], "visualizations": False},
+        )
+
+        actions: list[dict] = []
+        if self.actions_enabled:
+            actions.extend(song_actions)
+            actions.extend(self._build_theory_actions(meta.get("scale"), meta.get("chord_choices", [])))
+            actions = self._dedupe_actions(actions)
 
         return {
             "messages": [AIMessage(content=answer_text)],
@@ -250,6 +399,8 @@ class GuitarTutorAgent:
             "chord_choices": meta.get("chord_choices", []),
             "visualizations": meta.get("visualizations", False),
             "out_of_scope": False,
+            "actions": actions,
+            "memory_status": memory_status,
         }
 
     # --- Shared helpers ---
@@ -266,20 +417,90 @@ class GuitarTutorAgent:
                 result.model_dump() if hasattr(result, "model_dump") else result.dict()
             )
         except Exception as e:
-            logger.error(f"Structured output failed ({schema.__name__}): {e}")
+            logger.error("Structured output failed (%s): %s", getattr(schema, "__name__", str(schema)), e)
             return fallback
 
     @staticmethod
-    def _build_messages(conversation_history: List[dict], message: str) -> list:
+    def _coerce_text(content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and "text" in item:
+                    parts.append(str(item["text"]))
+                else:
+                    parts.append(str(item))
+            return "".join(parts)
+        return str(content)
+
+    @staticmethod
+    def _message_text(msg: Any) -> str:
+        content = getattr(msg, "content", "")
+        return GuitarTutorAgent._coerce_text(content)
+
+    @staticmethod
+    def _format_messages_for_prompt(messages: List[Any]) -> str:
+        lines: list[str] = []
+        for msg in messages:
+            role = "assistant" if isinstance(msg, AIMessage) else "user"
+            text = GuitarTutorAgent._message_text(msg).strip()
+            if text:
+                lines.append(f"{role}: {text}")
+        return "\n".join(lines) if lines else "None"
+
+    @staticmethod
+    def _history_to_messages(history: List[dict]) -> list:
         messages = []
-        if conversation_history:
-            for msg in conversation_history:
-                if msg.get("role") == "user":
-                    messages.append(HumanMessage(content=msg["content"]))
-                elif msg.get("role") == "assistant":
-                    messages.append(AIMessage(content=msg["content"]))
-        messages.append(HumanMessage(content=message))
+        for msg in history:
+            role = msg.get("role")
+            if role == "user":
+                messages.append(HumanMessage(content=msg.get("content", "")))
+            elif role == "assistant":
+                messages.append(AIMessage(content=msg.get("content", "")))
         return messages
+
+    def _thread_exists(self, config: dict) -> bool:
+        try:
+            return self.memory.get_tuple(config) is not None
+        except Exception:
+            # Conservative fallback if checkpointer API changes.
+            snapshot = self.graph.get_state(config)
+            values = getattr(snapshot, "values", None) or {}
+            tasks = getattr(snapshot, "tasks", None) or []
+            return bool(values) or bool(tasks)
+
+    def _build_graph_input(
+        self,
+        *,
+        message: str,
+        thread_exists: bool,
+        require_existing_thread: bool,
+        bootstrap_history: Optional[List[dict]],
+        ui_context: Optional[dict],
+        thread_id: str,
+    ) -> tuple[dict, str]:
+        if thread_exists:
+            memory_status = "restored"
+            messages = [HumanMessage(content=message)]
+        else:
+            if require_existing_thread:
+                raise ThreadNotFoundError(thread_id)
+            history = bootstrap_history or []
+            if history:
+                memory_status = "bootstrapped"
+                messages = self._history_to_messages(history)
+                messages.append(HumanMessage(content=message))
+            else:
+                memory_status = "fresh"
+                messages = [HumanMessage(content=message)]
+
+        graph_input = {
+            "messages": messages,
+            "ui_context": ui_context or {},
+            "memory_status": memory_status,
+        }
+        return graph_input, memory_status
 
     def _check_for_interrupt(self, config: dict) -> Optional[dict]:
         state_snapshot = self.graph.get_state(config)
@@ -290,7 +511,7 @@ class GuitarTutorAgent:
         return None
 
     @staticmethod
-    def _extract_result(output: dict) -> dict:
+    def _extract_result(output: dict, *, memory_status: str = "fresh") -> dict:
         return {
             "interrupted": False,
             "answer": output.get("answer", ""),
@@ -298,6 +519,8 @@ class GuitarTutorAgent:
             "chord_choices": output.get("chord_choices", []),
             "visualizations": output.get("visualizations", False),
             "out_of_scope": output.get("out_of_scope", False),
+            "actions": output.get("actions", []),
+            "memory_status": output.get("memory_status", memory_status),
         }
 
     @staticmethod
@@ -308,6 +531,393 @@ class GuitarTutorAgent:
                 return node
         return "processing"
 
+    def _build_theory_actions(self, scale: Optional[str], chord_choices: List[str]) -> list[dict]:
+        actions: list[dict] = []
+
+        for chord_name in chord_choices or []:
+            parsed = parse_chord_name(chord_name)
+            if not parsed:
+                continue
+            root, quality = parsed
+            actions.append(
+                {
+                    "type": "theory.show_chord",
+                    "root": root,
+                    "quality": quality,
+                }
+            )
+
+        if scale:
+            parsed_scale = parse_scale_name(scale)
+            if parsed_scale:
+                root, mode = parsed_scale
+                actions.append(
+                    {
+                        "type": "theory.show_scale",
+                        "root": root,
+                        "mode": mode,
+                    }
+                )
+
+        return actions
+
+    @staticmethod
+    def _dedupe_actions(actions: list[dict]) -> list[dict]:
+        deduped: list[dict] = []
+        seen: set[str] = set()
+        for action in actions:
+            signature = repr(sorted(action.items()))
+            if signature in seen:
+                continue
+            seen.add(signature)
+            deduped.append(action)
+        return deduped
+
+    def _run_song_tools(self, question_text: str, ui_context: dict) -> tuple[str, list[dict]]:
+        """Run bounded Songsterr lookups for song/measure intents and return context + actions."""
+        if not self.tool_calling_enabled:
+            return "", []
+
+        q = question_text.strip()
+        lower_q = q.lower()
+        search_query = self._extract_song_search_query(q)
+        song_intent = (
+            any(token in lower_q for token in ["song", "tab", "track", "measure", "riff", "verse", "chorus"])
+            or search_query is not None
+            or ("display" in lower_q and ("song" in lower_q or "tab" in lower_q))
+        )
+        if not song_intent:
+            return "", []
+
+        tool_context_lines: list[str] = []
+        actions: list[dict] = []
+
+        selected_song = (ui_context or {}).get("selected_song") or {}
+        selected_song_id = selected_song.get("song_id")
+        selected_track_index = int((ui_context or {}).get("selected_track_index") or 0)
+
+        # 1) Optional explicit search intent
+        if search_query:
+            try:
+                records = songsterr.search_songs_sync(search_query)
+                if records:
+                    actions.append({"type": "song.search", "query": search_query})
+                    best, score = self._choose_best_song_match(records, search_query)
+                    if best and score >= 55:
+                        actions.append({"type": "song.select", "song_id": best.song_id})
+                        actions.append({"type": "song.track.select", "track_index": 0})
+                        selected_song_id = best.song_id
+                        selected_track_index = 0
+                        tool_context_lines.append(
+                            f"Song search '{search_query}' matched: {best.artist} - {best.title} "
+                            f"(song_id={best.song_id}, score={score})."
+                        )
+                    else:
+                        tool_context_lines.append(
+                            f"Song search '{search_query}' returned results but no confident auto-select "
+                            f"(best score={score})."
+                        )
+                else:
+                    tool_context_lines.append(f"Song search '{search_query}' returned no results.")
+            except Exception as exc:
+                tool_context_lines.append(f"Song search failed for '{search_query}': {exc}")
+
+        # 2) Measure focus intent (for this song or selected search result)
+        requested_measure = self._extract_measure_index(q)
+        wants_measure_focus = (
+            (requested_measure is not None and self._is_measure_navigation_intent(lower_q))
+            or self._is_explicit_measure_navigation(lower_q)
+        )
+
+        # For deictic identification questions ("what chord is this"), trust selected UI beat context
+        # and avoid expensive network measure resolution.
+        if self._is_context_identification_question(lower_q):
+            selected_beat = (ui_context or {}).get("selected_beat_id")
+            highlighted = (ui_context or {}).get("highlighted_notes") or []
+            if selected_beat:
+                tool_context_lines.append(
+                    f"User selected beat context: beat_id={selected_beat}, highlighted_frets={highlighted}."
+                )
+            wants_measure_focus = False
+
+        if wants_measure_focus and selected_song_id is not None:
+            measure_index = requested_measure if requested_measure is not None else int((ui_context or {}).get("playhead_measure_index") or 0)
+            try:
+                resolved_measure, resolved_beat = songsterr.resolve_measure_focus_sync(
+                    song_id=int(selected_song_id),
+                    track_index=selected_track_index,
+                    requested_measure_index=max(0, measure_index),
+                )
+                action: dict[str, Any] = {
+                    "type": "song.measure.focus",
+                    "measure_index": resolved_measure,
+                }
+                if resolved_beat is not None:
+                    action["beat_index"] = resolved_beat
+                actions.append(action)
+                tool_context_lines.append(
+                    f"Resolved measure focus for song_id={selected_song_id}, track={selected_track_index}: "
+                    f"measure_index={resolved_measure}, beat_index={resolved_beat}."
+                )
+            except Exception as exc:
+                tool_context_lines.append(
+                    f"Could not resolve measure focus for song_id={selected_song_id}, "
+                    f"track={selected_track_index}: {exc}"
+                )
+
+        return "\n".join(tool_context_lines), self._dedupe_actions(actions)
+
+    @staticmethod
+    def _project_ui_context_for_prompt(ui_context: dict) -> dict:
+        """Pass only high-signal UI fields to prompts to reduce noise/token load."""
+        if not ui_context:
+            return {}
+
+        allowed_keys = [
+            "app_mode",
+            "display_mode",
+            "selected_tuning",
+            "selected_scale",
+            "selected_chord",
+            "selected_song",
+            "selected_track_index",
+            "song_view_mode",
+            "playhead_measure_index",
+            "selected_beat_id",
+            "highlighted_notes",
+        ]
+        projected: dict[str, Any] = {}
+        for key in allowed_keys:
+            if key in ui_context:
+                projected[key] = ui_context.get(key)
+
+        # Resolve highlighted fret positions to actual note names so the LLM
+        # doesn't have to do fret arithmetic (which it gets wrong).
+        highlighted = projected.get("highlighted_notes")
+        if highlighted and isinstance(highlighted, list):
+            tuning_id = ui_context.get("selected_tuning") or "standard"
+            custom_notes = ui_context.get("custom_tuning_notes")
+            tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
+
+            resolved = []
+            for hn in highlighted:
+                string_num = hn.get("string")
+                fret = hn.get("fret")
+                if string_num is None or fret is None:
+                    continue
+                # tuning_notes is indexed 0=string1, so string_num-1
+                idx = int(string_num) - 1
+                if 0 <= idx < len(tuning_notes):
+                    note = get_note_at_fret(tuning_notes[idx], int(fret))
+                    resolved.append({**hn, "note": note})
+                else:
+                    resolved.append(hn)
+            projected["highlighted_notes"] = resolved
+
+        return projected
+
+    @staticmethod
+    def _extract_song_search_query(question: str) -> Optional[str]:
+        text = question.strip()
+        lower = text.lower()
+
+        # Handle common "tabs for <song>" phrasing regardless of sentence prefix.
+        generic_for_match = re.search(
+            r"\b(?:tab|tabs|song|songs|track|tracks)\s+for\s+(.+)",
+            lower,
+        )
+        if generic_for_match:
+            query = generic_for_match.group(1).strip(" .,!?:;")
+            if query and "measure" not in query:
+                return query
+
+        patterns = [
+            r"(?:search|find|look\s*up|display|show)\s+(?:for\s+)?(?:song|songs|tab|tabs|track|tracks)\s+(.+)",
+            r"(?:show|display)\s+(?:me\s+)?(?:the\s+)?tab\s+for\s+(.+)",
+            r"look\s+up\s+(.+)",
+        ]
+        for pattern in patterns:
+            match = re.match(pattern, lower)
+            if not match:
+                continue
+            query = match.group(1).strip(" .,!?")
+            if query and len(query) >= 2:
+                return query
+
+        # Quoted title fallback: "Frisky" by Dominic Fike
+        quote_match = re.search(r'"([^"]+)"(?:\s+by\s+([a-z0-9 .,&\'-]+))?', lower)
+        if quote_match:
+            title = quote_match.group(1).strip(" .,!?:;")
+            artist = (quote_match.group(2) or "").strip(" .,!?:;")
+            if title and artist:
+                return f"{title} {artist}"
+            if title:
+                return title
+        return None
+
+    @staticmethod
+    def _normalize_search_text(text: str) -> str:
+        lowered = text.lower().strip()
+        lowered = re.sub(r"[^a-z0-9\s]", " ", lowered)
+        lowered = re.sub(r"\s+", " ", lowered).strip()
+        return lowered
+
+    def _split_query_title_artist(self, query: str) -> tuple[str, str]:
+        cleaned = self._normalize_search_text(query)
+        if " by " in cleaned:
+            title, artist = cleaned.split(" by ", 1)
+            return title.strip(), artist.strip()
+        return cleaned, ""
+
+    def _score_song_match(self, record: SongsterrRecord, query: str) -> int:
+        query_norm = self._normalize_search_text(query)
+        title_norm = self._normalize_search_text(record.title)
+        artist_norm = self._normalize_search_text(record.artist)
+        combined = f"{title_norm} {artist_norm}".strip()
+        q_title, q_artist = self._split_query_title_artist(query)
+
+        score = 0
+
+        # Strong exact/near-exact signals first.
+        if query_norm == combined:
+            score += 120
+        if q_title and q_title == title_norm:
+            score += 90
+        if q_artist and q_artist == artist_norm:
+            score += 80
+        if q_title and title_norm.startswith(q_title):
+            score += 40
+        if q_artist and artist_norm.startswith(q_artist):
+            score += 35
+
+        # Token overlap fallback.
+        q_tokens = set(query_norm.split())
+        c_tokens = set(combined.split())
+        if q_tokens and c_tokens:
+            overlap = len(q_tokens & c_tokens)
+            score += overlap * 8
+            # Penalize extra unrelated tokens for close-title collisions.
+            score -= max(0, len(c_tokens - q_tokens)) * 2
+
+        # Small boost for exact title even if artist differs slightly.
+        if q_title and title_norm == q_title:
+            score += 15
+
+        return score
+
+    def _choose_best_song_match(
+        self, records: List[SongsterrRecord], query: str
+    ) -> tuple[Optional[SongsterrRecord], int]:
+        if not records:
+            return None, 0
+
+        scored = [(record, self._score_song_match(record, query)) for record in records[:25]]
+        scored.sort(key=lambda x: x[1], reverse=True)
+        best_record, best_score = scored[0]
+        return best_record, best_score
+
+    @staticmethod
+    def _extract_measure_index(question: str) -> Optional[int]:
+        match = re.search(r"\bmeasure\s*#?\s*(\d+)\b", question.lower())
+        if not match:
+            return None
+
+        # Users speak in 1-based measure numbers; action contract is 0-based.
+        one_based = int(match.group(1))
+        return max(0, one_based - 1)
+
+    @staticmethod
+    def _is_context_identification_question(lower_question: str) -> bool:
+        return any(
+            phrase in lower_question
+            for phrase in [
+                "what chord is this",
+                "which chord is this",
+                "what is this chord",
+                "identify this chord",
+                "name this chord",
+            ]
+        )
+
+    @staticmethod
+    def _has_strong_ui_context(ui_context: dict) -> bool:
+        if not ui_context:
+            return False
+        highlighted = ui_context.get("highlighted_notes") or []
+        has_highlighted = isinstance(highlighted, list) and len(highlighted) >= 2
+        has_selected_beat = bool(ui_context.get("selected_beat_id"))
+        has_song_or_playhead = bool(ui_context.get("selected_song")) or (
+            ui_context.get("playhead_measure_index") is not None
+        )
+        return (has_selected_beat or has_song_or_playhead) and has_highlighted
+
+    @staticmethod
+    def _is_measure_navigation_intent(lower_question: str) -> bool:
+        return any(
+            token in lower_question
+            for token in [
+                "go to",
+                "jump to",
+                "navigate to",
+                "move to",
+                "focus",
+                "show me",
+                "display",
+                "scroll to",
+                "play from",
+                "start at",
+            ]
+        )
+
+    @staticmethod
+    def _is_explicit_measure_navigation(lower_question: str) -> bool:
+        patterns = [
+            r"\b(?:go|jump|move|navigate|scroll|start|play)\s+.*\bmeasure\b",
+            r"\bmeasure\s+\d+\s*(?:please|now|next)?\b",
+        ]
+        return any(re.search(pattern, lower_question) for pattern in patterns)
+
+    def _maybe_refresh_summary(self, state: dict) -> tuple[str, int]:
+        """Maintain a rolling summary for long threads (logical compaction)."""
+        running_summary = state.get("running_summary", "") or ""
+        summary_turn_count = int(state.get("summary_turn_count", 0) or 0)
+
+        if not self.summary_enabled:
+            return running_summary, summary_turn_count
+
+        messages = state.get("messages", [])
+        if not messages:
+            return running_summary, summary_turn_count
+
+        user_turns = sum(1 for m in messages if isinstance(m, HumanMessage))
+        if user_turns <= 0:
+            return running_summary, summary_turn_count
+
+        message_text = "\n".join(self._message_text(m) for m in messages)
+        threshold_hit = len(message_text) >= self.summary_char_threshold
+        interval_hit = user_turns % self.summary_turn_interval == 0 and user_turns != summary_turn_count
+
+        if not (threshold_hit or interval_hit):
+            return running_summary, summary_turn_count
+
+        keep_count = self.recent_turn_window * 2
+        older_messages = messages[:-keep_count] if len(messages) > keep_count else []
+        if not older_messages:
+            return running_summary, summary_turn_count
+
+        older_text = self._format_messages_for_prompt(older_messages)
+        summary_prompt = SUMMARY_INSTRUCTIONS.format(
+            running_summary=running_summary or "None",
+            older_messages=older_text,
+        )
+        try:
+            summary = self.llm.invoke([SystemMessage(content=summary_prompt)]).content
+            new_summary = self._coerce_text(summary).strip()
+            return new_summary, user_turns
+        except Exception as exc:
+            logger.warning("Summary refresh failed: %s", exc)
+            return running_summary, summary_turn_count
+
     # --- Public API: synchronous ---
 
     def chat(
@@ -315,12 +925,25 @@ class GuitarTutorAgent:
         message: str,
         conversation_history: List[dict] = None,
         thread_id: Optional[str] = "1",
+        bootstrap_history: List[dict] | None = None,
+        require_existing_thread: bool = False,
+        ui_context: Optional[dict] = None,
     ) -> dict:
         config = {"configurable": {"thread_id": thread_id}}
-        messages = self._build_messages(conversation_history or [], message)
+        thread_exists = self._thread_exists(config)
+
+        fallback_bootstrap = bootstrap_history if bootstrap_history else (conversation_history or [])
+        graph_input, memory_status = self._build_graph_input(
+            message=message,
+            thread_exists=thread_exists,
+            require_existing_thread=require_existing_thread,
+            bootstrap_history=fallback_bootstrap,
+            ui_context=ui_context,
+            thread_id=str(thread_id),
+        )
 
         output = None
-        for event in self.graph.stream({"messages": messages}, config=config, stream_mode="values"):
+        for event in self.graph.stream(graph_input, config=config, stream_mode="values"):
             output = event
 
         interrupt_data = self._check_for_interrupt(config)
@@ -333,16 +956,21 @@ class GuitarTutorAgent:
                 "chord_choices": [],
                 "visualizations": False,
                 "out_of_scope": False,
+                "actions": [],
+                "memory_status": memory_status,
             }
 
-        return self._extract_result(output)
+        return self._extract_result(output or {}, memory_status=memory_status)
 
     def resume_chat(
         self,
         human_response: str,
         thread_id: Optional[str] = "1",
+        ui_context: Optional[dict] = None,
     ) -> dict:
         config = {"configurable": {"thread_id": thread_id}}
+        if not self._thread_exists(config):
+            raise ThreadNotFoundError(str(thread_id))
 
         output = None
         for event in self.graph.stream(
@@ -352,7 +980,11 @@ class GuitarTutorAgent:
         ):
             output = event
 
-        return self._extract_result(output)
+        # Persist freshest ui context for subsequent turns.
+        if ui_context:
+            self.graph.update_state(config, {"ui_context": ui_context})
+
+        return self._extract_result(output or {}, memory_status="restored")
 
     def check_interrupt(self, thread_id: str = "1") -> Optional[dict]:
         config = {"configurable": {"thread_id": thread_id}}
@@ -360,24 +992,24 @@ class GuitarTutorAgent:
 
     # --- Public API: streaming (SSE) ---
 
-    def _iter_stream(self, graph_input, config) -> Generator[dict, None, None]:
+    def _iter_stream(self, graph_input, config, *, memory_status: str) -> Generator[dict, None, None]:
         """Shared streaming logic: yields status, token, interrupt, and answer events."""
         last_output = None
         in_answer_node = False
         answer_tokens_started = False
 
         for mode, event in self.graph.stream(
-            graph_input, config=config, stream_mode=["messages", "values"]
+            graph_input,
+            config=config,
+            stream_mode=["messages", "values"],
         ):
             if mode == "messages":
                 chunk, metadata = event
                 node = metadata.get("langgraph_node", "")
                 has_content = chunk.content and not getattr(chunk, "tool_call_chunks", None)
-                # Only yield tokens from the generate_answer node, and only after
-                # we've confirmed via the values stream that we're in that node.
-                # Skip JSON-like chunks from the structured metadata call.
+                # Only yield tokens from generate_answer, and skip JSON-like chunks.
                 if node == "generate_answer" and in_answer_node and has_content:
-                    text = chunk.content
+                    text = self._coerce_text(chunk.content)
                     if not answer_tokens_started:
                         stripped = text.strip()
                         if stripped.startswith("{") or stripped.startswith("["):
@@ -388,7 +1020,7 @@ class GuitarTutorAgent:
                 node = self._identify_node(event)
                 if node == "generate_answer":
                     in_answer_node = True
-                logger.debug(f"Stream event from node: {node}")
+                logger.debug("Stream event from node: %s", node)
                 yield {"event": "status", "data": {"node": node}}
                 last_output = event
 
@@ -398,28 +1030,52 @@ class GuitarTutorAgent:
             return
 
         if last_output:
-            yield {"event": "answer", "data": self._extract_result(last_output)}
+            payload = self._extract_result(last_output, memory_status=memory_status)
+            yield {"event": "answer", "data": payload}
 
     def stream_chat(
         self,
         message: str,
         conversation_history: List[dict] = None,
         thread_id: Optional[str] = "1",
+        bootstrap_history: List[dict] | None = None,
+        require_existing_thread: bool = False,
+        ui_context: Optional[dict] = None,
     ) -> Generator[dict, None, None]:
         """Stream chat processing as SSE event dicts."""
         config = {"configurable": {"thread_id": thread_id}}
-        messages = self._build_messages(conversation_history or [], message)
-        yield from self._iter_stream({"messages": messages}, config)
+        thread_exists = self._thread_exists(config)
+
+        fallback_bootstrap = bootstrap_history if bootstrap_history else (conversation_history or [])
+        graph_input, memory_status = self._build_graph_input(
+            message=message,
+            thread_exists=thread_exists,
+            require_existing_thread=require_existing_thread,
+            bootstrap_history=fallback_bootstrap,
+            ui_context=ui_context,
+            thread_id=str(thread_id),
+        )
+
+        yield from self._iter_stream(graph_input, config, memory_status=memory_status)
 
     def stream_resume(
         self,
         human_response: str,
         thread_id: Optional[str] = "1",
+        ui_context: Optional[dict] = None,
     ) -> Generator[dict, None, None]:
         """Stream resume processing as SSE event dicts."""
         config = {"configurable": {"thread_id": thread_id}}
+        if not self._thread_exists(config):
+            raise ThreadNotFoundError(str(thread_id))
+
+        if ui_context:
+            self.graph.update_state(config, {"ui_context": ui_context})
+
         yield from self._iter_stream(
-            Command(resume={"response": human_response}), config
+            Command(resume={"response": human_response}),
+            config,
+            memory_status="restored",
         )
 
 
@@ -435,8 +1091,10 @@ def get_agent() -> GuitarTutorAgent:
     if _agent_instance is None:
         settings = get_settings()
         logger.info(
-            f"Initializing agent: provider={settings.llm_provider}, "
-            f"model={settings.llm_model_name}, base_url={settings.llm_base_url}"
+            "Initializing agent: provider=%s, model=%s, base_url=%s",
+            settings.llm_provider,
+            settings.llm_model_name,
+            settings.llm_base_url,
         )
         _agent_instance = GuitarTutorAgent(
             model_name=settings.llm_model_name,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,14 @@ class Settings(BaseSettings):
     openrouter_api_key: Optional[str] = None
     model_name: Optional[str] = None
     log_level: str = "INFO"
+    agent_actions_enabled: bool = True
+    agent_tool_calling_enabled: bool = True
+    agent_summary_enabled: bool = True
+    agent_summary_turn_interval: int = 6
+    agent_summary_char_threshold: int = 7000
+    agent_recent_turn_window: int = 10
+    agent_checkpoint_backend: str = "memory"  # memory | sqlite
+    agent_checkpoint_sqlite_path: str = ".agent_checkpoints.sqlite"
 
     _PROVIDER_DEFAULTS: dict = {
         "openai": {"base_url": None, "default_model": "gpt-4o-mini"},

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     openai_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None
     model_name: Optional[str] = None
+    llm_timeout_seconds: Optional[float] = 300.0
     log_level: str = "INFO"
     agent_actions_enabled: bool = True
     agent_tool_calling_enabled: bool = True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import DynamicCORSMiddleware, get_settings, setup_logging
 from app.exceptions import register_exception_handlers
-from app.routers import fretboard, tunings, scales, chords, agent
+from app.routers import fretboard, tunings, scales, chords, agent, songs
 
 setup_logging()
 
@@ -32,6 +32,7 @@ app.include_router(tunings.router, prefix="/api", tags=["tunings"])
 app.include_router(scales.router, prefix="/api", tags=["scales"])
 app.include_router(chords.router, prefix="/api", tags=["chords"])
 app.include_router(agent.router, prefix="/api", tags=["agent"])
+app.include_router(songs.router, prefix="/api", tags=["songs"])
 
 
 @app.get("/")

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -2,9 +2,9 @@
 Pydantic schemas for agent chat endpoints.
 """
 
-from typing import List, Optional
+from typing import Annotated, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AgentMessage(BaseModel):
@@ -13,10 +13,58 @@ class AgentMessage(BaseModel):
     content: str
 
 
+class UiScaleContext(BaseModel):
+    root: Optional[str] = None
+    mode: Optional[str] = None
+
+
+class UiChordContext(BaseModel):
+    root: Optional[str] = None
+    quality: Optional[str] = None
+
+
+class UiSongContext(BaseModel):
+    song_id: Optional[int] = None
+    artist: Optional[str] = None
+    title: Optional[str] = None
+    has_chords: Optional[bool] = None
+
+
+class UiHighlightedNote(BaseModel):
+    string: int
+    fret: int
+
+
+class UiContext(BaseModel):
+    """Structured UI context passed from frontend for agent awareness."""
+
+    app_mode: Optional[Literal["scale", "chord", "song"]] = None
+    display_mode: Optional[Literal["notes", "intervals"]] = None
+
+    selected_tuning: Optional[str] = None
+    custom_tuning_notes: Optional[List[str]] = None
+
+    selected_scale: Optional[UiScaleContext] = None
+    selected_chord: Optional[UiChordContext] = None
+
+    selected_song: Optional[UiSongContext] = None
+    selected_track_index: Optional[int] = None
+    song_view_mode: Optional[Literal["tab", "chords"]] = None
+
+    playhead_measure_index: Optional[int] = None
+    selected_beat_id: Optional[str] = None
+    highlighted_notes: Optional[List[UiHighlightedNote]] = None
+
+    model_config = {"extra": "allow"}
+
+
 class AgentRequest(BaseModel):
     """Request for /api/agent/chat endpoint."""
     message: str
-    conversation_history: List[AgentMessage] = []
+    conversation_history: List[AgentMessage] = Field(default_factory=list)  # Deprecated fallback
+    bootstrap_history: List[AgentMessage] = Field(default_factory=list)
+    require_existing_thread: bool = False
+    ui_context: Optional[UiContext] = None
     thread_id: Optional[str] = "default"
 
 
@@ -38,7 +86,7 @@ class ScaleApiRequest(BaseModel):
 
 class ApiRequests(BaseModel):
     """Container for parsed API requests from agent response."""
-    chords: List[ChordApiRequest] = []
+    chords: List[ChordApiRequest] = Field(default_factory=list)
     scale: Optional[ScaleApiRequest] = None
 
 
@@ -46,15 +94,64 @@ class ResumeRequest(BaseModel):
     """Request for /api/agent/resume endpoint."""
     response: str  # User's response to the clarifying question
     thread_id: str = "default"
+    ui_context: Optional[UiContext] = None
+
+
+class SongSearchAction(BaseModel):
+    type: Literal["song.search"]
+    query: str
+
+
+class SongSelectAction(BaseModel):
+    type: Literal["song.select"]
+    song_id: int
+
+
+class SongTrackSelectAction(BaseModel):
+    type: Literal["song.track.select"]
+    track_index: int
+
+
+class SongMeasureFocusAction(BaseModel):
+    type: Literal["song.measure.focus"]
+    measure_index: int
+    beat_index: Optional[int] = None
+
+
+class TheoryShowChordAction(BaseModel):
+    type: Literal["theory.show_chord"]
+    root: str
+    quality: str
+
+
+class TheoryShowScaleAction(BaseModel):
+    type: Literal["theory.show_scale"]
+    root: str
+    mode: str
+
+
+AgentAction = Annotated[
+    Union[
+        SongSearchAction,
+        SongSelectAction,
+        SongTrackSelectAction,
+        SongMeasureFocusAction,
+        TheoryShowChordAction,
+        TheoryShowScaleAction,
+    ],
+    Field(discriminator="type"),
+]
 
 
 class AgentResponse(BaseModel):
     """Response for /api/agent/chat endpoint."""
     answer: str
     scale: Optional[str] = None
-    chord_choices: List[str] = []
+    chord_choices: List[str] = Field(default_factory=list)
     visualizations: bool = False
     out_of_scope: bool = False
     interrupted: bool = False
     interrupt_data: Optional[dict] = None
     api_requests: Optional[ApiRequests] = None
+    actions: List[AgentAction] = Field(default_factory=list)
+    memory_status: Literal["restored", "bootstrapped", "fresh"] = "fresh"

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -130,6 +130,21 @@ class TheoryShowScaleAction(BaseModel):
     mode: str
 
 
+class FretboardHighlightPosition(BaseModel):
+    string: int  # 1-6 (1 = high E)
+    fret: int    # 0-22
+
+
+class FretboardHighlightGroup(BaseModel):
+    name: str
+    positions: List[FretboardHighlightPosition]
+
+
+class FretboardHighlightAction(BaseModel):
+    type: Literal["fretboard.highlight"]
+    groups: List[FretboardHighlightGroup]
+
+
 AgentAction = Annotated[
     Union[
         SongSearchAction,
@@ -138,6 +153,7 @@ AgentAction = Annotated[
         SongMeasureFocusAction,
         TheoryShowChordAction,
         TheoryShowScaleAction,
+        FretboardHighlightAction,
     ],
     Field(discriminator="type"),
 ]

--- a/backend/app/models/songsterr.py
+++ b/backend/app/models/songsterr.py
@@ -69,6 +69,7 @@ class TrackSummary(BaseModel):
     instrument: str
     is_vocal: bool = False
     is_empty: bool = False
+    tuning: list[int] | None = None
 
 
 class SongSearchResult(BaseModel):

--- a/backend/app/models/songsterr.py
+++ b/backend/app/models/songsterr.py
@@ -1,0 +1,105 @@
+"""Pydantic models for Songsterr API responses and our song endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+# --- Songsterr API response models (parsed from external API) ---
+
+class SongsterrTrack(BaseModel):
+    model_config = {"extra": "ignore"}
+
+    instrument_id: int = Field(alias="instrumentId")
+    instrument: str
+    views: int = 0
+    name: str = ""
+    tuning: list[int] | None = None
+    difficulty: int | None = None
+    hash: str = ""
+
+
+class SongsterrRevisionTrack(SongsterrTrack):
+    is_vocal_track: bool = Field(default=False, alias="isVocalTrack")
+    is_empty: bool = Field(default=False, alias="isEmpty")
+
+
+class SongsterrRecord(BaseModel):
+    model_config = {"extra": "ignore"}
+
+    song_id: int = Field(alias="songId")
+    artist_id: int = Field(alias="artistId")
+    artist: str
+    title: str
+    has_chords: bool = Field(default=False, alias="hasChords")
+    has_player: bool = Field(default=False, alias="hasPlayer")
+    tracks: list[SongsterrTrack]
+    default_track: int = Field(default=0, alias="defaultTrack")
+    popular_track: int = Field(default=0, alias="popularTrack")
+
+
+class SongsterrRevisionResponse(BaseModel):
+    model_config = {"extra": "ignore"}
+
+    revision_id: int = Field(alias="revisionId")
+    song_id: int = Field(alias="songId")
+    artist: str
+    title: str
+    description: str = ""
+    tracks: list[SongsterrRevisionTrack]
+    default_track: int = Field(default=0, alias="defaultTrack")
+    popular_track: int = Field(default=0, alias="popularTrack")
+    image: str | None = None
+    source: str | None = None
+
+
+class SongsterrChordsResponse(BaseModel):
+    model_config = {"extra": "ignore"}
+
+    song_id: int = Field(alias="songId")
+    artist: str
+    title: str
+    chordpro: str
+    chords_revision_id: int = Field(alias="chordsRevisionId")
+
+
+# --- Our API response models ---
+
+class TrackSummary(BaseModel):
+    index: int
+    name: str
+    instrument: str
+    is_vocal: bool = False
+    is_empty: bool = False
+
+
+class SongSearchResult(BaseModel):
+    song_id: int
+    artist: str
+    title: str
+    has_chords: bool
+    tracks: list[TrackSummary]
+
+
+class SongSearchResponse(BaseModel):
+    results: list[SongSearchResult]
+
+
+class SongTracksResponse(BaseModel):
+    song_id: int
+    artist: str
+    title: str
+    tracks: list[TrackSummary]
+
+
+class TabDataResponse(BaseModel):
+    song_id: int
+    artist: str
+    title: str
+    track_name: str
+    tab_data: dict
+
+
+class ChordProResponse(BaseModel):
+    song_id: int
+    artist: str
+    title: str
+    chordpro: str

--- a/backend/app/music/chords.py
+++ b/backend/app/music/chords.py
@@ -52,9 +52,9 @@ def index_to_note(index: int) -> str:
     return CHROMATIC_NOTES[index % 12]
 
 
-def get_note_at_position(string: int, fret: int) -> str:
+def get_note_at_position(string: int, fret: int, tuning: dict[int, int] | None = None) -> str:
     """Get the note at a specific string/fret position."""
-    open_note = STANDARD_TUNING[string]
+    open_note = (tuning or STANDARD_TUNING)[string]
     return index_to_note(open_note + fret)
 
 

--- a/backend/app/music/chords.py
+++ b/backend/app/music/chords.py
@@ -2,8 +2,8 @@
 
 from typing import Dict, List
 
-# Chromatic scale
-CHROMATIC_NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+# Chromatic scale (using flats — the music-theory standard)
+CHROMATIC_NOTES = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
 
 # Chord intervals (semitones from root) with interval names
 CHORD_INTERVALS = {
@@ -42,8 +42,8 @@ STANDARD_TUNING = {
 
 def note_to_index(note: str) -> int:
     """Convert note name to chromatic index (0-11)."""
-    flat_to_sharp = {"Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#"}
-    normalized = flat_to_sharp.get(note, note)
+    sharp_to_flat = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
+    normalized = sharp_to_flat.get(note, note)
     return CHROMATIC_NOTES.index(normalized)
 
 

--- a/backend/app/music/chords_db.py
+++ b/backend/app/music/chords_db.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from app.music.chords import (
     CHORD_INTERVALS,
+    STANDARD_TUNING,
     _get_quality_suffix,
     get_note_at_position,
     note_to_index,
@@ -101,6 +102,7 @@ def get_voicing_positions(
     root: str,
     quality: str,
     max_fret: int = 22,
+    tuning: dict[int, int] | None = None,
 ) -> list[dict[str, Any]] | None:
     """
     Get voicings for a chord from chords-db converted to app format.
@@ -111,6 +113,13 @@ def get_voicing_positions(
     if entry is None:
         return None
 
+    effective_tuning = tuning or STANDARD_TUNING
+    # Per-string semitone offset: positive means target string is lower → fret must increase
+    string_offsets = {
+        s: STANDARD_TUNING[s] - effective_tuning[s] for s in range(1, 7)
+    }
+    is_transposed = any(v != 0 for v in string_offsets.values())
+
     root_index = note_to_index(root)
     interval_map = _interval_name_map(quality)
     quality_suffix = _get_quality_suffix(quality)
@@ -120,6 +129,7 @@ def get_voicing_positions(
     for position_index, db_position in enumerate(entry["positions"], start=1):
         base_fret = int(db_position["baseFret"])
         positions: list[dict[str, Any]] = []
+        voicing_valid = True
 
         # chords-db frets are ordered low-E to high-E. App strings are 1=high-E, 6=low-E.
         for db_string_index, fret_value in enumerate(db_position["frets"]):
@@ -132,11 +142,21 @@ def get_voicing_positions(
             else:
                 actual_fret = base_fret + fret_value - 1
 
-            note_name = get_note_at_position(string_number, actual_fret)
+            # Transpose for non-standard tuning
+            if is_transposed:
+                actual_fret = actual_fret + string_offsets[string_number]
+                if actual_fret < 0:
+                    voicing_valid = False
+                    break
+
+            note_name = get_note_at_position(string_number, actual_fret, effective_tuning)
             semitone_distance = (note_to_index(note_name) - root_index) % 12
             interval_name = interval_map.get(semitone_distance)
 
             if interval_name is None:
+                if is_transposed:
+                    voicing_valid = False
+                    break
                 continue
 
             positions.append(
@@ -149,7 +169,7 @@ def get_voicing_positions(
                 }
             )
 
-        if not positions:
+        if not voicing_valid or not positions:
             continue
 
         replicated_positions = list(positions)
@@ -169,7 +189,7 @@ def get_voicing_positions(
                 {
                     "string": pos["string"],
                     "fret": octave_fret,
-                    "note": get_note_at_position(pos["string"], octave_fret),
+                    "note": get_note_at_position(pos["string"], octave_fret, effective_tuning),
                     "interval": pos["interval"],
                     "is_root": pos["is_root"],
                 }
@@ -178,13 +198,14 @@ def get_voicing_positions(
 
         replicated_positions.sort(key=lambda p: (p["string"], p["fret"]))
         played_frets = [p["fret"] for p in replicated_positions]
+        transposed_base = base_fret + string_offsets.get(6, 0) if is_transposed else base_fret
         voicing_label = f"Pos {position_index}"
         voicings.append(
             {
                 "label": voicing_label,
                 "name": f"{root}{quality_suffix} ({voicing_label})",
                 "color": "accent",
-                "base_fret": base_fret,
+                "base_fret": max(transposed_base, 1),
                 "min_fret": min(played_frets),
                 "max_fret": max(played_frets),
                 "positions": replicated_positions,

--- a/backend/app/music/notes.py
+++ b/backend/app/music/notes.py
@@ -2,11 +2,11 @@
 Music theory: Note definitions and chromatic calculations.
 """
 
-# All 12 chromatic notes (using sharps as default)
-CHROMATIC_NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+# All 12 chromatic notes using flats (the music-theory standard for enharmonics).
+CHROMATIC_NOTES = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
 
-# Enharmonic equivalents (for display purposes)
-ENHARMONIC_MAP = {
+# Sharps accepted as input, mapped to their flat equivalents.
+SHARP_TO_FLAT = {
     "C#": "Db",
     "D#": "Eb",
     "F#": "Gb",
@@ -14,34 +14,32 @@ ENHARMONIC_MAP = {
     "A#": "Bb",
 }
 
-# Reverse mapping
-FLAT_TO_SHARP = {v: k for k, v in ENHARMONIC_MAP.items()}
+
+def _normalize_note(note: str) -> str:
+    """Normalize a note name to the flat-based canonical form."""
+    return SHARP_TO_FLAT.get(note, note)
 
 
 def get_note_at_fret(open_note: str, fret: int) -> str:
     """
     Calculate the note at a given fret position.
-    
+
     Args:
-        open_note: The note of the open string (e.g., "E", "A")
+        open_note: The note of the open string (e.g., "E", "A", "Bb")
         fret: The fret number (0 = open string)
-    
+
     Returns:
-        The note name at that position
+        The note name at that position (using flat notation)
     """
-    # Normalize open_note to sharp notation
-    if open_note in FLAT_TO_SHARP:
-        open_note = FLAT_TO_SHARP[open_note]
-    
-    # Find the index of the open note
+    normalized = _normalize_note(open_note)
+
     try:
-        start_index = CHROMATIC_NOTES.index(open_note)
+        start_index = CHROMATIC_NOTES.index(normalized)
     except ValueError:
         raise ValueError(f"Invalid note: {open_note}")
-    
-    # Calculate new note index (wrapping around)
+
     new_index = (start_index + fret) % 12
-    
+
     return CHROMATIC_NOTES[new_index]
 
 

--- a/backend/app/music/scales.py
+++ b/backend/app/music/scales.py
@@ -52,30 +52,14 @@ MINOR_DIATONIC_CHORDS = [
     ("VII", "major"),
 ]
 
-CHROMATIC_NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
-
-# Enharmonic equivalents for display
-ENHARMONIC_MAP = {
-    "C#": "Db",
-    "D#": "Eb",
-    "F#": "Gb",
-    "G#": "Ab",
-    "A#": "Bb",
-}
+CHROMATIC_NOTES = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
 
 
 def note_to_index(note: str) -> int:
     """Convert note name to chromatic index (0-11)."""
-    # Handle flats by converting to sharps
-    flat_to_sharp = {
-        "Db": "C#",
-        "Eb": "D#",
-        "Gb": "F#",
-        "Ab": "G#",
-        "Bb": "A#",
-    }
-    note = flat_to_sharp.get(note, note)
-    return CHROMATIC_NOTES.index(note)
+    sharp_to_flat = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
+    normalized = sharp_to_flat.get(note, note)
+    return CHROMATIC_NOTES.index(normalized)
 
 
 def index_to_note(index: int) -> str:
@@ -102,8 +86,8 @@ def get_scale_degree(note: str, root: str, mode: str) -> Tuple[int, str]:
     scale_notes = get_scale_notes(root, mode)
     
     # Normalize note for comparison
-    flat_to_sharp = {"Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#"}
-    normalized = flat_to_sharp.get(note, note)
+    sharp_to_flat = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
+    normalized = sharp_to_flat.get(note, note)
     
     if normalized in scale_notes:
         degree = scale_notes.index(normalized) + 1

--- a/backend/app/music/tunings.py
+++ b/backend/app/music/tunings.py
@@ -18,7 +18,7 @@ TUNINGS = {
     "half_step_down": {
         "id": "half_step_down",
         "name": "Half Step Down",
-        "notes": ["D#", "A#", "F#", "C#", "G#", "D#"],
+        "notes": ["Eb", "Bb", "Gb", "Db", "Ab", "Eb"],
     },
     "full_step_down": {
         "id": "full_step_down",

--- a/backend/app/music/tunings.py
+++ b/backend/app/music/tunings.py
@@ -57,3 +57,25 @@ def get_tuning_notes(tuning_id: str) -> list[str]:
     """Get the notes for a tuning."""
     tuning = TUNINGS.get(tuning_id, TUNINGS["standard"])
     return tuning["notes"]
+
+
+def notes_to_semitone_map(notes: list[str]) -> dict[int, int]:
+    """Convert a list of 6 note names (string 1→6) to {string_number: semitone_value}.
+
+    Example: ["E", "B", "G", "D", "A", "E"] → {1: 4, 2: 11, 3: 7, 4: 2, 5: 9, 6: 4}
+    """
+    from app.music.chords import note_to_index
+
+    return {i + 1: note_to_index(note) for i, note in enumerate(notes)}
+
+
+def match_tuning_id(notes: list[str]) -> str | None:
+    """Check if a list of note names matches a known tuning. Returns the tuning ID or None."""
+    from app.music.chords import note_to_index
+
+    target = [note_to_index(n) for n in notes]
+    for tuning_id, tuning in TUNINGS.items():
+        candidate = [note_to_index(n) for n in tuning["notes"]]
+        if candidate == target:
+            return tuning_id
+    return None

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -5,10 +5,10 @@ Agent API routes — synchronous and SSE streaming endpoints.
 import json
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
-from app.agent.agent import get_agent
+from app.agent.agent import ThreadNotFoundError, get_agent
 from app.agent.parser import build_api_requests_from_response
 from app.models.agent import (
     AgentRequest,
@@ -34,6 +34,8 @@ def _build_agent_response(result: dict) -> AgentResponse:
             interrupt_data=result.get("interrupt_data"),
             visualizations=False,
             out_of_scope=False,
+            actions=[],
+            memory_status=result.get("memory_status", "fresh"),
         )
 
     api_requests_data = _parse_api_requests(result)
@@ -46,6 +48,8 @@ def _build_agent_response(result: dict) -> AgentResponse:
         out_of_scope=result.get("out_of_scope", False),
         interrupted=False,
         api_requests=api_requests_data,
+        actions=result.get("actions", []),
+        memory_status=result.get("memory_status", "fresh"),
     )
 
 
@@ -73,6 +77,20 @@ def _history_to_dicts(request: AgentRequest) -> list[dict]:
     return [{"role": msg.role, "content": msg.content} for msg in request.conversation_history]
 
 
+def _bootstrap_to_dicts(request: AgentRequest) -> list[dict]:
+    """Choose bootstrap history with deprecated conversation_history fallback."""
+    if request.bootstrap_history:
+        return [{"role": msg.role, "content": msg.content} for msg in request.bootstrap_history]
+    # Deprecated fallback for older clients.
+    return _history_to_dicts(request)
+
+
+def _ui_context_dict(obj) -> dict:
+    if not obj:
+        return {}
+    return obj.model_dump(exclude_none=True)
+
+
 # --- Synchronous endpoints ---
 
 @router.post("/agent/chat", response_model=AgentResponse)
@@ -80,11 +98,24 @@ async def chat_with_agent(request: AgentRequest):
     """Chat with the Guitar Tutor agent."""
     logger.info(f"Chat request: thread={request.thread_id}, message={request.message[:80]}")
     agent = get_agent()
-    result = agent.chat(
-        message=request.message,
-        conversation_history=_history_to_dicts(request),
-        thread_id=request.thread_id,
-    )
+    try:
+        result = agent.chat(
+            message=request.message,
+            conversation_history=_history_to_dicts(request),
+            bootstrap_history=_bootstrap_to_dicts(request),
+            require_existing_thread=request.require_existing_thread,
+            ui_context=_ui_context_dict(request.ui_context),
+            thread_id=request.thread_id,
+        )
+    except ThreadNotFoundError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "THREAD_NOT_FOUND",
+                "detail": str(exc),
+                "thread_id": exc.thread_id,
+            },
+        )
     return _build_agent_response(result)
 
 
@@ -105,10 +136,21 @@ async def resume_agent_chat(request: ResumeRequest):
     """Resume agent chat after user answers a clarifying question."""
     logger.info(f"Resume request: thread={request.thread_id}")
     agent = get_agent()
-    result = agent.resume_chat(
-        human_response=request.response,
-        thread_id=request.thread_id,
-    )
+    try:
+        result = agent.resume_chat(
+            human_response=request.response,
+            thread_id=request.thread_id,
+            ui_context=_ui_context_dict(request.ui_context),
+        )
+    except ThreadNotFoundError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "THREAD_NOT_FOUND",
+                "detail": str(exc),
+                "thread_id": exc.thread_id,
+            },
+        )
     return _build_agent_response(result)
 
 
@@ -125,6 +167,9 @@ async def stream_chat_with_agent(request: AgentRequest):
             for event in agent.stream_chat(
                 message=request.message,
                 conversation_history=_history_to_dicts(request),
+                bootstrap_history=_bootstrap_to_dicts(request),
+                require_existing_thread=request.require_existing_thread,
+                ui_context=_ui_context_dict(request.ui_context),
                 thread_id=request.thread_id,
             ):
                 event_type = event["event"]
@@ -137,7 +182,13 @@ async def stream_chat_with_agent(request: AgentRequest):
                 yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
             yield "event: done\ndata: {}\n\n"
-
+        except ThreadNotFoundError as exc:
+            payload = {
+                "code": "THREAD_NOT_FOUND",
+                "detail": str(exc),
+                "thread_id": exc.thread_id,
+            }
+            yield f"event: error\ndata: {json.dumps(payload)}\n\n"
         except Exception as e:
             logger.exception(f"SSE stream error: {e}")
             yield f"event: error\ndata: {json.dumps({'detail': str(e)})}\n\n"
@@ -159,6 +210,7 @@ async def stream_resume_agent_chat(request: ResumeRequest):
             agent = get_agent()
             for event in agent.stream_resume(
                 human_response=request.response,
+                ui_context=_ui_context_dict(request.ui_context),
                 thread_id=request.thread_id,
             ):
                 event_type = event["event"]
@@ -170,7 +222,13 @@ async def stream_resume_agent_chat(request: ResumeRequest):
                 yield f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
             yield "event: done\ndata: {}\n\n"
-
+        except ThreadNotFoundError as exc:
+            payload = {
+                "code": "THREAD_NOT_FOUND",
+                "detail": str(exc),
+                "thread_id": exc.thread_id,
+            }
+            yield f"event: error\ndata: {json.dumps(payload)}\n\n"
         except Exception as e:
             logger.exception(f"SSE resume stream error: {e}")
             yield f"event: error\ndata: {json.dumps({'detail': str(e)})}\n\n"

--- a/backend/app/routers/chords.py
+++ b/backend/app/routers/chords.py
@@ -1,6 +1,6 @@
 """Chords API routes."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.models.music import (
     ChordQualitiesResponse,
@@ -16,6 +16,7 @@ from app.music.chords import (
     get_chord_notes,
 )
 from app.music.chords_db import get_voicing_positions
+from app.music.tunings import get_tuning_notes, notes_to_semitone_map
 
 router = APIRouter()
 
@@ -48,13 +49,20 @@ async def get_chord_qualities():
 
 
 @router.get("/chords/{root}/{quality}", response_model=ChordResponse)
-async def get_chord(root: str, quality: str):
+async def get_chord(
+    root: str,
+    quality: str,
+    tuning: str = Query(default="standard", description="Tuning ID"),
+    tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
+):
     """
     Get chord information with voicings from chords-db.
 
     Args:
         root: Root note (e.g., "C", "F#", "Bb")
         quality: Chord quality (e.g., "major", "minor", "dominant7")
+        tuning: Tuning ID (e.g., "standard", "drop_d")
+        tuning_notes: Comma-separated custom tuning notes (overrides tuning ID)
     """
     if root not in VALID_ROOTS:
         raise HTTPException(status_code=400, detail=f"Invalid root note: {root}")
@@ -62,8 +70,19 @@ async def get_chord(root: str, quality: str):
     if quality not in CHORD_INTERVALS:
         raise HTTPException(status_code=400, detail=f"Invalid chord quality: {quality}")
 
+    # Resolve tuning
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
+        tuning_map = notes_to_semitone_map(notes)
+    elif tuning != "standard":
+        tuning_map = notes_to_semitone_map(get_tuning_notes(tuning))
+    else:
+        tuning_map = None
+
     chord_notes = get_chord_notes(root, quality)
-    voicing_data = get_voicing_positions(root, quality)
+    voicing_data = get_voicing_positions(root, quality, tuning=tuning_map)
 
     if voicing_data is None:
         raise HTTPException(

--- a/backend/app/routers/chords.py
+++ b/backend/app/routers/chords.py
@@ -2,43 +2,11 @@
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.models.music import (
-    ChordQualitiesResponse,
-    ChordQualityInfo,
-    ChordResponse,
-    ChordVoicing,
-    ChordVoicingPosition,
-)
-from app.music.chords import (
-    CHORD_INTERVALS,
-    _get_quality_suffix,
-    get_available_chord_qualities,
-    get_chord_notes,
-)
-from app.music.chords_db import get_voicing_positions
-from app.music.tunings import get_tuning_notes, notes_to_semitone_map
+from app.models.music import ChordQualitiesResponse, ChordQualityInfo, ChordResponse
+from app.music.chords import get_available_chord_qualities
+from app.services.chord_service import get_chord
 
 router = APIRouter()
-
-VALID_ROOTS = [
-    "C",
-    "C#",
-    "Db",
-    "D",
-    "D#",
-    "Eb",
-    "E",
-    "F",
-    "F#",
-    "Gb",
-    "G",
-    "G#",
-    "Ab",
-    "A",
-    "A#",
-    "Bb",
-    "B",
-]
 
 
 @router.get("/chords/qualities", response_model=ChordQualitiesResponse)
@@ -49,76 +17,16 @@ async def get_chord_qualities():
 
 
 @router.get("/chords/{root}/{quality}", response_model=ChordResponse)
-async def get_chord(
+async def get_chord_endpoint(
     root: str,
     quality: str,
     tuning: str = Query(default="standard", description="Tuning ID"),
     tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
 ):
-    """
-    Get chord information with voicings from chords-db.
-
-    Args:
-        root: Root note (e.g., "C", "F#", "Bb")
-        quality: Chord quality (e.g., "major", "minor", "dominant7")
-        tuning: Tuning ID (e.g., "standard", "drop_d")
-        tuning_notes: Comma-separated custom tuning notes (overrides tuning ID)
-    """
-    if root not in VALID_ROOTS:
-        raise HTTPException(status_code=400, detail=f"Invalid root note: {root}")
-
-    if quality not in CHORD_INTERVALS:
-        raise HTTPException(status_code=400, detail=f"Invalid chord quality: {quality}")
-
-    # Resolve tuning
-    if tuning_notes:
-        notes = [n.strip() for n in tuning_notes.split(",")]
-        if len(notes) != 6:
-            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
-        tuning_map = notes_to_semitone_map(notes)
-    elif tuning != "standard":
-        tuning_map = notes_to_semitone_map(get_tuning_notes(tuning))
-    else:
-        tuning_map = None
-
-    chord_notes = get_chord_notes(root, quality)
-    voicing_data = get_voicing_positions(root, quality, tuning=tuning_map)
-
-    if voicing_data is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Chord {root} {quality} not available in voicings database",
-        )
-
-    voicings = []
-    for voicing in voicing_data:
-        positions = [
-            ChordVoicingPosition(
-                string=pos["string"],
-                fret=pos["fret"],
-                note=pos["note"],
-                interval=pos["interval"],
-                is_root=pos["is_root"],
-            )
-            for pos in voicing["positions"]
-        ]
-
-        voicings.append(
-            ChordVoicing(
-                label=voicing["label"],
-                name=voicing["name"],
-                color=voicing["color"],
-                base_fret=voicing["base_fret"],
-                min_fret=voicing["min_fret"],
-                max_fret=voicing["max_fret"],
-                positions=positions,
-            )
-        )
-
-    return ChordResponse(
-        root=root,
-        quality=quality,
-        display_name=f"{root}{_get_quality_suffix(quality)}",
-        chord_notes=chord_notes,
-        voicings=voicings,
-    )
+    """Get chord information with voicings."""
+    try:
+        return get_chord(root, quality, tuning, tuning_notes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))

--- a/backend/app/routers/fretboard.py
+++ b/backend/app/routers/fretboard.py
@@ -1,51 +1,20 @@
-from fastapi import APIRouter, Query
+"""Fretboard API routes."""
 
-from app.models.music import FretboardResponse, NotePosition
-from app.music.notes import generate_fretboard
-from app.music.tunings import get_tuning_notes
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.music import FretboardResponse
+from app.services.fretboard_service import get_fretboard
 
 router = APIRouter()
 
-FRET_COUNT = 22
-
 
 @router.get("/fretboard", response_model=FretboardResponse)
-async def get_fretboard(
+async def get_fretboard_endpoint(
     tuning: str = Query(default="standard", description="Tuning ID (e.g., 'standard', 'drop_d')"),
     tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
 ):
-    """
-    Get the complete fretboard with all note positions.
-
-    Returns a chromatic grid for 6 strings × 23 positions (open + 22 frets).
-    """
-    if tuning_notes:
-        notes = [n.strip() for n in tuning_notes.split(",")]
-        if len(notes) != 6:
-            from fastapi import HTTPException
-            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
-        resolved_notes = notes
-        tuning = "custom"
-    else:
-        resolved_notes = get_tuning_notes(tuning)
-    fretboard_data = generate_fretboard(resolved_notes, FRET_COUNT)
-    
-    # Convert to response format
-    strings = []
-    for string_data in fretboard_data:
-        string_positions = [
-            NotePosition(
-                string=pos["string"],
-                fret=pos["fret"],
-                note=pos["note"]
-            )
-            for pos in string_data
-        ]
-        strings.append(string_positions)
-    
-    return FretboardResponse(
-        tuning=tuning,
-        tuning_notes=resolved_notes,
-        strings=strings,
-        fret_count=FRET_COUNT,
-    )
+    """Get the complete fretboard with all note positions."""
+    try:
+        return get_fretboard(tuning, tuning_notes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/app/routers/fretboard.py
+++ b/backend/app/routers/fretboard.py
@@ -11,15 +11,24 @@ FRET_COUNT = 22
 
 @router.get("/fretboard", response_model=FretboardResponse)
 async def get_fretboard(
-    tuning: str = Query(default="standard", description="Tuning ID (e.g., 'standard', 'drop_d')")
+    tuning: str = Query(default="standard", description="Tuning ID (e.g., 'standard', 'drop_d')"),
+    tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
 ):
     """
     Get the complete fretboard with all note positions.
-    
+
     Returns a chromatic grid for 6 strings × 23 positions (open + 22 frets).
     """
-    tuning_notes = get_tuning_notes(tuning)
-    fretboard_data = generate_fretboard(tuning_notes, FRET_COUNT)
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
+        resolved_notes = notes
+        tuning = "custom"
+    else:
+        resolved_notes = get_tuning_notes(tuning)
+    fretboard_data = generate_fretboard(resolved_notes, FRET_COUNT)
     
     # Convert to response format
     strings = []
@@ -36,7 +45,7 @@ async def get_fretboard(
     
     return FretboardResponse(
         tuning=tuning,
-        tuning_notes=tuning_notes,
+        tuning_notes=resolved_notes,
         strings=strings,
         fret_count=FRET_COUNT,
     )

--- a/backend/app/routers/scales.py
+++ b/backend/app/routers/scales.py
@@ -34,34 +34,43 @@ async def get_scale(
     root: str,
     mode: str,
     tuning: str = Query(default="standard", description="Guitar tuning to use"),
+    tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
 ):
     """
     Get scale information and fretboard positions.
-    
+
     Args:
         root: Root note (e.g., "C", "F#", "Bb")
         mode: Scale mode (e.g., "major", "pentatonic_minor")
         tuning: Guitar tuning to use
+        tuning_notes: Comma-separated custom tuning notes (overrides tuning ID)
     """
     # Validate root note
     valid_roots = ["C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"]
     if root not in valid_roots:
         raise HTTPException(status_code=400, detail=f"Invalid root note: {root}")
-    
+
     # Validate mode
     if mode not in SCALE_INTERVALS:
         raise HTTPException(status_code=400, detail=f"Invalid scale mode: {mode}")
-    
-    # Validate tuning
-    if tuning not in TUNINGS:
-        raise HTTPException(status_code=400, detail=f"Invalid tuning: {tuning}")
-    
+
+    # Resolve tuning
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
+        resolved_notes = notes
+    else:
+        # Validate tuning ID
+        if tuning not in TUNINGS:
+            raise HTTPException(status_code=400, detail=f"Invalid tuning: {tuning}")
+        resolved_notes = get_tuning_notes(tuning)
+
     # Get scale notes
     scale_notes = get_scale_notes(root, mode)
-    
-    # Get tuning notes and generate fretboard
-    tuning_notes = get_tuning_notes(tuning)
-    fretboard = generate_fretboard(tuning_notes)
+
+    # Generate fretboard with resolved tuning
+    fretboard = generate_fretboard(resolved_notes)
     
     # Find all positions on fretboard that are in the scale
     positions = []

--- a/backend/app/routers/scales.py
+++ b/backend/app/routers/scales.py
@@ -1,112 +1,29 @@
-"""
-Scales API routes.
-"""
+"""Scales API routes."""
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.models.music import (
-    ScalesListResponse,
-    ScaleResponse,
-    ScaleNotePosition,
-    DiatonicChord,
-)
-from app.music.scales import (
-    get_available_scales,
-    get_scale_notes,
-    get_scale_degree,
-    get_diatonic_chords,
-    SCALE_INTERVALS,
-)
-from app.music.notes import generate_fretboard
-from app.music.tunings import TUNINGS, get_tuning_notes
+from app.models.music import ScaleResponse, ScalesListResponse
+from app.music.scales import get_available_scales
+from app.services.scale_service import get_scale
 
 router = APIRouter()
 
 
 @router.get("/scales", response_model=ScalesListResponse)
-async def get_scales():
+async def list_scales():
     """Get list of all available scales."""
     return ScalesListResponse(scales=get_available_scales())
 
 
 @router.get("/scales/{root}/{mode}", response_model=ScaleResponse)
-async def get_scale(
+async def get_scale_endpoint(
     root: str,
     mode: str,
     tuning: str = Query(default="standard", description="Guitar tuning to use"),
     tuning_notes: str | None = Query(default=None, description="Comma-separated custom tuning notes, string 1 to 6"),
 ):
-    """
-    Get scale information and fretboard positions.
-
-    Args:
-        root: Root note (e.g., "C", "F#", "Bb")
-        mode: Scale mode (e.g., "major", "pentatonic_minor")
-        tuning: Guitar tuning to use
-        tuning_notes: Comma-separated custom tuning notes (overrides tuning ID)
-    """
-    # Validate root note
-    valid_roots = ["C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"]
-    if root not in valid_roots:
-        raise HTTPException(status_code=400, detail=f"Invalid root note: {root}")
-
-    # Validate mode
-    if mode not in SCALE_INTERVALS:
-        raise HTTPException(status_code=400, detail=f"Invalid scale mode: {mode}")
-
-    # Resolve tuning
-    if tuning_notes:
-        notes = [n.strip() for n in tuning_notes.split(",")]
-        if len(notes) != 6:
-            raise HTTPException(status_code=400, detail="tuning_notes must have exactly 6 notes")
-        resolved_notes = notes
-    else:
-        # Validate tuning ID
-        if tuning not in TUNINGS:
-            raise HTTPException(status_code=400, detail=f"Invalid tuning: {tuning}")
-        resolved_notes = get_tuning_notes(tuning)
-
-    # Get scale notes
-    scale_notes = get_scale_notes(root, mode)
-
-    # Generate fretboard with resolved tuning
-    fretboard = generate_fretboard(resolved_notes)
-    
-    # Find all positions on fretboard that are in the scale
-    positions = []
-
-    # Normalize root to flat notation for comparison
-    sharp_to_flat = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
-    normalized_root = sharp_to_flat.get(root, root)
-
-    for string_notes in fretboard:
-        for note_pos in string_notes:
-            note_name = note_pos["note"]
-            normalized_note = sharp_to_flat.get(note_name, note_name)
-
-            if normalized_note in scale_notes:
-                degree, degree_label = get_scale_degree(note_name, root, mode)
-                is_root = normalized_note == normalized_root
-                
-                positions.append(ScaleNotePosition(
-                    string=note_pos["string"],
-                    fret=note_pos["fret"],
-                    note=note_pos["note"],
-                    is_root=is_root,
-                    degree=degree,
-                    degree_label=degree_label,
-                ))
-    
-    # Get diatonic chords
-    diatonic = get_diatonic_chords(root, mode)
-    diatonic_chords = [
-        DiatonicChord(**chord) for chord in diatonic
-    ]
-    
-    return ScaleResponse(
-        root=root,
-        mode=mode,
-        scale_notes=scale_notes,
-        positions=positions,
-        diatonic_chords=diatonic_chords,
-    )
+    """Get scale information and fretboard positions."""
+    try:
+        return get_scale(root, mode, tuning, tuning_notes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/app/routers/scales.py
+++ b/backend/app/routers/scales.py
@@ -74,18 +74,18 @@ async def get_scale(
     
     # Find all positions on fretboard that are in the scale
     positions = []
-    
-    # Normalize root for comparison
-    flat_to_sharp = {"Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#"}
-    normalized_root = flat_to_sharp.get(root, root)
-    
+
+    # Normalize root to flat notation for comparison
+    sharp_to_flat = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
+    normalized_root = sharp_to_flat.get(root, root)
+
     for string_notes in fretboard:
         for note_pos in string_notes:
-            # Check if this note is in the scale
-            normalized_note = flat_to_sharp.get(note_pos["note"], note_pos["note"])
-            
+            note_name = note_pos["note"]
+            normalized_note = sharp_to_flat.get(note_name, note_name)
+
             if normalized_note in scale_notes:
-                degree, degree_label = get_scale_degree(note_pos["note"], root, mode)
+                degree, degree_label = get_scale_degree(note_name, root, mode)
                 is_root = normalized_note == normalized_root
                 
                 positions.append(ScaleNotePosition(

--- a/backend/app/routers/songs.py
+++ b/backend/app/routers/songs.py
@@ -30,6 +30,7 @@ async def search_songs(q: str = Query(..., min_length=1, description="Search que
                 index=i,
                 name=t.name or t.instrument,
                 instrument=t.instrument,
+                tuning=t.tuning,
             )
             for i, t in enumerate(r.tracks)
         ]
@@ -63,6 +64,7 @@ async def get_song_tracks(song_id: int):
             instrument=t.instrument,
             is_vocal=t.is_vocal_track,
             is_empty=t.is_empty,
+            tuning=t.tuning,
         )
         for i, t in enumerate(revision.tracks)
     ]

--- a/backend/app/routers/songs.py
+++ b/backend/app/routers/songs.py
@@ -1,0 +1,134 @@
+"""Song search and tab data endpoints (proxies Songsterr API)."""
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.songsterr import (
+    ChordProResponse,
+    SongSearchResponse,
+    SongSearchResult,
+    SongTracksResponse,
+    TabDataResponse,
+    TrackSummary,
+)
+from app.services import songsterr
+
+router = APIRouter()
+
+
+@router.get("/songs/search", response_model=SongSearchResponse)
+async def search_songs(q: str = Query(..., min_length=1, description="Search query")):
+    """Search for songs by artist/title."""
+    try:
+        records = await songsterr.search_songs(q)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Songsterr API error: {exc}")
+
+    results = []
+    for r in records[:20]:
+        tracks = [
+            TrackSummary(
+                index=i,
+                name=t.name or t.instrument,
+                instrument=t.instrument,
+            )
+            for i, t in enumerate(r.tracks)
+        ]
+        results.append(
+            SongSearchResult(
+                song_id=r.song_id,
+                artist=r.artist,
+                title=r.title,
+                has_chords=r.has_chords,
+                tracks=tracks,
+            )
+        )
+
+    return SongSearchResponse(results=results)
+
+
+@router.get("/songs/{song_id}/tracks", response_model=SongTracksResponse)
+async def get_song_tracks(song_id: int):
+    """Get available tracks for a song (from latest revision)."""
+    try:
+        revision = await songsterr.get_song_revision(song_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Songsterr API error: {exc}")
+
+    tracks = [
+        TrackSummary(
+            index=i,
+            name=t.name or t.instrument,
+            instrument=t.instrument,
+            is_vocal=t.is_vocal_track,
+            is_empty=t.is_empty,
+        )
+        for i, t in enumerate(revision.tracks)
+    ]
+
+    return SongTracksResponse(
+        song_id=revision.song_id,
+        artist=revision.artist,
+        title=revision.title,
+        tracks=tracks,
+    )
+
+
+@router.get("/songs/{song_id}/tab", response_model=TabDataResponse)
+async def get_tab(song_id: int, track: int = Query(0, ge=0, description="Track index")):
+    """Get tab data for a specific track of a song."""
+    try:
+        revision = await songsterr.get_song_revision(song_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Songsterr API error: {exc}")
+
+    if not revision.image:
+        raise HTTPException(status_code=404, detail="No tab data available for this song")
+    if track >= len(revision.tracks):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Track index {track} out of range ({len(revision.tracks)} tracks available)",
+        )
+
+    try:
+        tab_data = await songsterr.get_tab_data(
+            revision.song_id, revision.revision_id, revision.image, track,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to fetch tab data: {exc}")
+
+    track_info = revision.tracks[track]
+    return TabDataResponse(
+        song_id=revision.song_id,
+        artist=revision.artist,
+        title=revision.title,
+        track_name=track_info.name or track_info.instrument,
+        tab_data=tab_data,
+    )
+
+
+@router.get("/songs/{song_id}/chords", response_model=ChordProResponse)
+async def get_chords(song_id: int):
+    """Get ChordPro (lyrics + chords) for a song."""
+    try:
+        revision = await songsterr.get_song_revision(song_id)
+    except Exception:
+        revision = None
+
+    try:
+        chordpro = await songsterr.get_chordpro(song_id)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Songsterr API error: {exc}")
+
+    if not chordpro:
+        raise HTTPException(status_code=404, detail="No chord data available for this song")
+
+    return ChordProResponse(
+        song_id=song_id,
+        artist=revision.artist if revision else "",
+        title=revision.title if revision else "",
+        chordpro=chordpro,
+    )

--- a/backend/app/services/chord_service.py
+++ b/backend/app/services/chord_service.py
@@ -1,0 +1,87 @@
+"""Service layer for chord lookups and voicing assembly."""
+
+from app.models.music import ChordResponse, ChordVoicing, ChordVoicingPosition
+from app.music.chords import (
+    CHORD_INTERVALS,
+    _get_quality_suffix,
+    get_chord_notes,
+)
+from app.music.chords_db import get_voicing_positions
+from app.music.tunings import get_tuning_notes, notes_to_semitone_map
+
+VALID_ROOTS = [
+    "C", "C#", "Db", "D", "D#", "Eb", "E", "F",
+    "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B",
+]
+
+
+def _resolve_tuning_map(
+    tuning: str = "standard",
+    tuning_notes: str | None = None,
+) -> dict[int, int] | None:
+    """Resolve tuning to a semitone map, or None for standard."""
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            raise ValueError("tuning_notes must have exactly 6 notes")
+        return notes_to_semitone_map(notes)
+    if tuning != "standard":
+        return notes_to_semitone_map(get_tuning_notes(tuning))
+    return None
+
+
+def get_chord(
+    root: str,
+    quality: str,
+    tuning: str = "standard",
+    tuning_notes: str | None = None,
+) -> ChordResponse:
+    """Build a full ChordResponse for the given root/quality/tuning.
+
+    Raises ValueError for invalid input, LookupError if no voicings found.
+    """
+    if root not in VALID_ROOTS:
+        raise ValueError(f"Invalid root note: {root}")
+    if quality not in CHORD_INTERVALS:
+        raise ValueError(f"Invalid chord quality: {quality}")
+
+    tuning_map = _resolve_tuning_map(tuning, tuning_notes)
+    chord_notes = get_chord_notes(root, quality)
+    voicing_data = get_voicing_positions(root, quality, tuning=tuning_map)
+
+    if voicing_data is None:
+        raise LookupError(
+            f"Chord {root} {quality} not available in voicings database"
+        )
+
+    voicings: list[ChordVoicing] = []
+    for voicing in voicing_data:
+        positions = [
+            ChordVoicingPosition(
+                string=pos["string"],
+                fret=pos["fret"],
+                note=pos["note"],
+                interval=pos["interval"],
+                is_root=pos["is_root"],
+            )
+            for pos in voicing["positions"]
+        ]
+        voicings.append(
+            ChordVoicing(
+                label=voicing["label"],
+                name=voicing["name"],
+                color=voicing["color"],
+                base_fret=voicing["base_fret"],
+                min_fret=voicing["min_fret"],
+                max_fret=voicing["max_fret"],
+                positions=positions,
+            )
+        )
+
+    return ChordResponse(
+        root=root,
+        quality=quality,
+        display_name=f"{root}{_get_quality_suffix(quality)}",
+        chord_notes=chord_notes,
+        voicings=voicings,
+    )

--- a/backend/app/services/fretboard_service.py
+++ b/backend/app/services/fretboard_service.py
@@ -1,0 +1,39 @@
+"""Service layer for fretboard generation."""
+
+from app.models.music import FretboardResponse, NotePosition
+from app.music.notes import generate_fretboard
+from app.music.tunings import get_tuning_notes
+
+FRET_COUNT = 22
+
+
+def get_fretboard(
+    tuning: str = "standard",
+    tuning_notes: str | None = None,
+) -> FretboardResponse:
+    """Build a full FretboardResponse for the given tuning."""
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            raise ValueError("tuning_notes must have exactly 6 notes")
+        resolved_notes = notes
+        tuning = "custom"
+    else:
+        resolved_notes = get_tuning_notes(tuning)
+
+    fretboard_data = generate_fretboard(resolved_notes, FRET_COUNT)
+
+    strings = [
+        [
+            NotePosition(string=pos["string"], fret=pos["fret"], note=pos["note"])
+            for pos in string_data
+        ]
+        for string_data in fretboard_data
+    ]
+
+    return FretboardResponse(
+        tuning=tuning,
+        tuning_notes=resolved_notes,
+        strings=strings,
+        fret_count=FRET_COUNT,
+    )

--- a/backend/app/services/scale_service.py
+++ b/backend/app/services/scale_service.py
@@ -1,0 +1,83 @@
+"""Service layer for scale lookups and fretboard position mapping."""
+
+from app.models.music import DiatonicChord, ScaleNotePosition, ScaleResponse
+from app.music.notes import generate_fretboard
+from app.music.scales import (
+    SCALE_INTERVALS,
+    get_diatonic_chords,
+    get_scale_degree,
+    get_scale_notes,
+)
+from app.music.tunings import TUNINGS, get_tuning_notes
+
+VALID_ROOTS = [
+    "C", "C#", "Db", "D", "D#", "Eb", "E", "F",
+    "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B",
+]
+
+SHARP_TO_FLAT = {"C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"}
+
+
+def resolve_tuning_notes(
+    tuning: str = "standard",
+    tuning_notes: str | None = None,
+) -> list[str]:
+    """Resolve tuning to a list of 6 note names. Raises ValueError on bad input."""
+    if tuning_notes:
+        notes = [n.strip() for n in tuning_notes.split(",")]
+        if len(notes) != 6:
+            raise ValueError("tuning_notes must have exactly 6 notes")
+        return notes
+    if tuning not in TUNINGS:
+        raise ValueError(f"Invalid tuning: {tuning}")
+    return get_tuning_notes(tuning)
+
+
+def get_scale(
+    root: str,
+    mode: str,
+    tuning: str = "standard",
+    tuning_notes: str | None = None,
+) -> ScaleResponse:
+    """Build a full ScaleResponse for the given root/mode/tuning."""
+    if root not in VALID_ROOTS:
+        raise ValueError(f"Invalid root note: {root}")
+    if mode not in SCALE_INTERVALS:
+        raise ValueError(f"Invalid scale mode: {mode}")
+
+    resolved_notes = resolve_tuning_notes(tuning, tuning_notes)
+    scale_notes = get_scale_notes(root, mode)
+    fretboard = generate_fretboard(resolved_notes)
+
+    normalized_root = SHARP_TO_FLAT.get(root, root)
+
+    positions: list[ScaleNotePosition] = []
+    for string_notes in fretboard:
+        for note_pos in string_notes:
+            note_name = note_pos["note"]
+            normalized_note = SHARP_TO_FLAT.get(note_name, note_name)
+
+            if normalized_note in scale_notes:
+                degree, degree_label = get_scale_degree(note_name, root, mode)
+                positions.append(
+                    ScaleNotePosition(
+                        string=note_pos["string"],
+                        fret=note_pos["fret"],
+                        note=note_name,
+                        is_root=normalized_note == normalized_root,
+                        degree=degree,
+                        degree_label=degree_label,
+                    )
+                )
+
+    diatonic_chords = [
+        DiatonicChord(**chord) for chord in get_diatonic_chords(root, mode)
+    ]
+
+    return ScaleResponse(
+        root=root,
+        mode=mode,
+        scale_notes=scale_notes,
+        positions=positions,
+        diatonic_chords=diatonic_chords,
+    )

--- a/backend/app/services/songsterr.py
+++ b/backend/app/services/songsterr.py
@@ -1,0 +1,190 @@
+"""Service layer for Songsterr API integration.
+
+Proxies requests to Songsterr's search, revision, tab CDN, and ChordPro endpoints.
+"""
+
+import gzip
+import json
+import zlib
+from typing import Any
+
+import httpx
+
+from app.models.songsterr import (
+    SongsterrChordsResponse,
+    SongsterrRecord,
+    SongsterrRevisionResponse,
+    SongsterrRevisionTrack,
+)
+
+SONGSTERR_API = "https://www.songsterr.com/api"
+CHORDPRO_CDN = "https://chordpro2.songsterr.com"
+
+# Mirrors Songsterr web client tab CDN routing logic.
+TABS_CDN_HOSTS = [
+    "dqsljvtekg760",
+    "d34shlm8p2ums2",
+    "d3cqchs6g3b5ew",
+]
+TABS_STAGE_CDN_HOST = "d3d3l6a6rcgkaf"
+TABS_PART_CDN_HOSTS = [
+    "d3rrfvx08uyjp1",
+    "dodkcbujl0ebx",
+    "dj1usja78sinh",
+]
+
+
+def _decompress(data: bytes) -> str:
+    """Decode response data — handles plain text, gzip, and zlib."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    try:
+        return gzip.decompress(data).decode("utf-8")
+    except gzip.BadGzipFile:
+        pass
+    return zlib.decompress(data).decode("utf-8")
+
+
+def _extract_search_records(payload: Any) -> list[dict[str, Any]]:
+    """Normalize Songsterr search payload into a list of record objects.
+
+    Songsterr has returned both:
+      - a raw list of records
+      - an object wrapper (e.g. {"records": [...]})
+    """
+    if isinstance(payload, list):
+        if all(isinstance(item, dict) for item in payload):
+            return payload
+        raise ValueError("Unexpected Songsterr search list format")
+
+    if isinstance(payload, dict):
+        for key in ("records", "results", "songs", "data"):
+            value = payload.get(key)
+            if isinstance(value, list) and all(isinstance(item, dict) for item in value):
+                return value
+
+    raise ValueError("Unexpected Songsterr search response format")
+
+
+def _build_tab_candidate_urls(song_id: int, revision_id: int, image: str | None, track_index: int) -> list[str]:
+    candidate_urls: list[str] = []
+    if image:
+        if image.endswith("-stage"):
+            candidate_urls.append(
+                f"https://{TABS_STAGE_CDN_HOST}.cloudfront.net/"
+                f"{song_id}/{revision_id}/{image}/{track_index}.json"
+            )
+        candidate_urls.extend(
+            f"https://{host}.cloudfront.net/{song_id}/{revision_id}/{image}/{track_index}.json"
+            for host in TABS_CDN_HOSTS
+        )
+    else:
+        candidate_urls.extend(
+            f"https://{host}.cloudfront.net/part/{revision_id}/{track_index}"
+            for host in TABS_PART_CDN_HOSTS
+        )
+    return candidate_urls
+
+
+async def search_songs(query: str) -> list[SongsterrRecord]:
+    """Search Songsterr for songs matching the query."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(f"{SONGSTERR_API}/search", params={"pattern": query})
+        resp.raise_for_status()
+        records_payload = _extract_search_records(resp.json())
+        return [SongsterrRecord.model_validate(r) for r in records_payload]
+
+
+async def get_song_revision(song_id: int) -> SongsterrRevisionResponse:
+    """Get the latest revision for a song."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        rev_resp = await client.get(f"{SONGSTERR_API}/meta/{song_id}/revisions")
+        rev_resp.raise_for_status()
+        revisions = rev_resp.json()
+        if not revisions:
+            raise ValueError(f"No revisions found for song {song_id}")
+
+        revision_id = revisions[0]["revisionId"]
+        resp = await client.get(f"{SONGSTERR_API}/revision/{revision_id}")
+        resp.raise_for_status()
+        return SongsterrRevisionResponse.model_validate(resp.json())
+
+
+async def get_tab_data(
+    song_id: int,
+    revision_id: int,
+    image: str,
+    track_index: int,
+) -> dict:
+    """Fetch and decompress tab JSON from the CDN."""
+    candidate_urls = _build_tab_candidate_urls(song_id, revision_id, image, track_index)
+
+    if not candidate_urls:
+        raise ValueError("No candidate tab URLs could be built")
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        last_error: Exception | None = None
+        for url in candidate_urls:
+            try:
+                resp = await client.get(url)
+                if resp.status_code == 404:
+                    continue
+                resp.raise_for_status()
+                return json.loads(_decompress(resp.content))
+            except Exception as exc:
+                last_error = exc
+                continue
+
+    attempted = ", ".join(candidate_urls)
+    if last_error:
+        raise RuntimeError(
+            f"All tab CDN candidates failed for song={song_id}, rev={revision_id}, "
+            f"track={track_index}. Attempted: {attempted}",
+        ) from last_error
+    raise RuntimeError(
+        f"Tab data not found for song={song_id}, rev={revision_id}, track={track_index}. "
+        f"Attempted: {attempted}",
+    )
+
+
+async def get_chordpro(song_id: int) -> str | None:
+    """Get ChordPro text (lyrics + chords) for a song. Returns None if unavailable."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.get(f"{SONGSTERR_API}/chords/{song_id}")
+        if resp.status_code != 200:
+            return None
+
+        chords = SongsterrChordsResponse.model_validate(resp.json())
+        cp_url = (
+            f"{CHORDPRO_CDN}/{chords.song_id}"
+            f"/{chords.chords_revision_id}/{chords.chordpro}.chordpro"
+        )
+        cp_resp = await client.get(cp_url)
+        if cp_resp.status_code != 200:
+            return None
+
+        return _decompress(cp_resp.content)
+
+
+async def get_lyrics(
+    song_id: int,
+    revision: SongsterrRevisionResponse,
+) -> str | None:
+    """Fetch lyrics from the vocal track if available."""
+    vocal_idx: int | None = None
+    for i, t in enumerate(revision.tracks):
+        if isinstance(t, SongsterrRevisionTrack) and t.is_vocal_track:
+            vocal_idx = i
+            break
+    if vocal_idx is None or not revision.image:
+        return None
+
+    tab = await get_tab_data(
+        revision.song_id, revision.revision_id, revision.image, vocal_idx,
+    )
+    new_lyrics = tab.get("newLyrics", [])
+    if new_lyrics and new_lyrics[0].get("text"):
+        return new_lyrics[0]["text"]
+    return None

--- a/backend/app/services/songsterr.py
+++ b/backend/app/services/songsterr.py
@@ -88,10 +88,50 @@ def _build_tab_candidate_urls(song_id: int, revision_id: int, image: str | None,
     return candidate_urls
 
 
+def _extract_first_playable_beat_index(tab_data: dict, measure_index: int) -> int | None:
+    """Return the first beat index in a measure that has playable notes."""
+    measures = tab_data.get("measures") or []
+    if measure_index < 0 or measure_index >= len(measures):
+        return None
+
+    measure = measures[measure_index] or {}
+    voices = measure.get("voices") or []
+    if not voices:
+        return None
+
+    # Pick the voice with the most sounding notes.
+    best_beats: list[dict] = []
+    best_score = -1
+    for voice in voices:
+        beats = voice.get("beats") or []
+        score = 0
+        for beat in beats:
+            notes = beat.get("notes") or []
+            score += sum(1 for n in notes if not n.get("rest") and not n.get("dead"))
+        if score > best_score:
+            best_score = score
+            best_beats = beats
+
+    for idx, beat in enumerate(best_beats):
+        notes = beat.get("notes") or []
+        if any(not n.get("rest") and not n.get("dead") for n in notes):
+            return idx
+    return 0 if best_beats else None
+
+
 async def search_songs(query: str) -> list[SongsterrRecord]:
     """Search Songsterr for songs matching the query."""
     async with httpx.AsyncClient(timeout=15.0) as client:
         resp = await client.get(f"{SONGSTERR_API}/search", params={"pattern": query})
+        resp.raise_for_status()
+        records_payload = _extract_search_records(resp.json())
+        return [SongsterrRecord.model_validate(r) for r in records_payload]
+
+
+def search_songs_sync(query: str) -> list[SongsterrRecord]:
+    """Synchronous song search for agent-side tool usage."""
+    with httpx.Client(timeout=15.0) as client:
+        resp = client.get(f"{SONGSTERR_API}/search", params={"pattern": query})
         resp.raise_for_status()
         records_payload = _extract_search_records(resp.json())
         return [SongsterrRecord.model_validate(r) for r in records_payload]
@@ -108,6 +148,21 @@ async def get_song_revision(song_id: int) -> SongsterrRevisionResponse:
 
         revision_id = revisions[0]["revisionId"]
         resp = await client.get(f"{SONGSTERR_API}/revision/{revision_id}")
+        resp.raise_for_status()
+        return SongsterrRevisionResponse.model_validate(resp.json())
+
+
+def get_song_revision_sync(song_id: int) -> SongsterrRevisionResponse:
+    """Synchronous latest revision lookup for agent-side tool usage."""
+    with httpx.Client(timeout=15.0) as client:
+        rev_resp = client.get(f"{SONGSTERR_API}/meta/{song_id}/revisions")
+        rev_resp.raise_for_status()
+        revisions = rev_resp.json()
+        if not revisions:
+            raise ValueError(f"No revisions found for song {song_id}")
+
+        revision_id = revisions[0]["revisionId"]
+        resp = client.get(f"{SONGSTERR_API}/revision/{revision_id}")
         resp.raise_for_status()
         return SongsterrRevisionResponse.model_validate(resp.json())
 
@@ -147,6 +202,65 @@ async def get_tab_data(
         f"Tab data not found for song={song_id}, rev={revision_id}, track={track_index}. "
         f"Attempted: {attempted}",
     )
+
+
+def get_tab_data_sync(
+    song_id: int,
+    revision_id: int,
+    image: str | None,
+    track_index: int,
+) -> dict:
+    """Synchronous tab fetch and decompression for agent-side tool usage."""
+    candidate_urls = _build_tab_candidate_urls(song_id, revision_id, image, track_index)
+
+    if not candidate_urls:
+        raise ValueError("No candidate tab URLs could be built")
+
+    with httpx.Client(timeout=15.0) as client:
+        last_error: Exception | None = None
+        for url in candidate_urls:
+            try:
+                resp = client.get(url)
+                if resp.status_code == 404:
+                    continue
+                resp.raise_for_status()
+                return json.loads(_decompress(resp.content))
+            except Exception as exc:
+                last_error = exc
+                continue
+
+    attempted = ", ".join(candidate_urls)
+    if last_error:
+        raise RuntimeError(
+            f"All tab CDN candidates failed for song={song_id}, rev={revision_id}, "
+            f"track={track_index}. Attempted: {attempted}",
+        ) from last_error
+    raise RuntimeError(
+        f"Tab data not found for song={song_id}, rev={revision_id}, track={track_index}. "
+        f"Attempted: {attempted}",
+    )
+
+
+def resolve_measure_focus_sync(
+    song_id: int,
+    track_index: int,
+    requested_measure_index: int,
+) -> tuple[int, int | None]:
+    """Resolve a valid (measure_index, beat_index) focus target for a song track."""
+    revision = get_song_revision_sync(song_id)
+    tab_data = get_tab_data_sync(
+        song_id=revision.song_id,
+        revision_id=revision.revision_id,
+        image=revision.image,
+        track_index=track_index,
+    )
+    measures = tab_data.get("measures") or []
+    if not measures:
+        return 0, None
+
+    clamped_measure = max(0, min(requested_measure_index, len(measures) - 1))
+    beat_index = _extract_first_playable_beat_index(tab_data, clamped_measure)
+    return clamped_measure, beat_index
 
 
 async def get_chordpro(song_id: int) -> str | None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,6 @@ langchain-anthropic==1.0.0
 langchain-community
 jupyter==1.0.0
 langgraph-cli[inmem]==0.4.0
+httpx>=0.27.0
 typing-extensions>=4.0.0
 pytest==8.3.3

--- a/backend/tests/test_songsterr_service.py
+++ b/backend/tests/test_songsterr_service.py
@@ -3,6 +3,7 @@ from app.services.songsterr import (
     TABS_PART_CDN_HOSTS,
     TABS_STAGE_CDN_HOST,
     _build_tab_candidate_urls,
+    _extract_first_playable_beat_index,
     _extract_search_records,
 )
 
@@ -65,3 +66,41 @@ def test_build_tab_candidate_urls_without_image_uses_part_hosts():
         track_index=3,
     )
     assert urls == [f"https://{host}.cloudfront.net/part/2/3" for host in TABS_PART_CDN_HOSTS]
+
+
+def test_extract_first_playable_beat_index_prefers_sounding_notes():
+    tab_data = {
+        "measures": [
+            {
+                "voices": [
+                    {
+                        "beats": [
+                            {"notes": [{"rest": True}]},
+                            {"notes": [{"string": 0, "fret": 3}]},
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert _extract_first_playable_beat_index(tab_data, 0) == 1
+
+
+def test_extract_first_playable_beat_index_returns_zero_for_all_rests():
+    tab_data = {
+        "measures": [
+            {
+                "voices": [
+                    {
+                        "beats": [
+                            {"notes": [{"rest": True}]},
+                            {"notes": [{"dead": True}]},
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert _extract_first_playable_beat_index(tab_data, 0) == 0

--- a/backend/tests/test_songsterr_service.py
+++ b/backend/tests/test_songsterr_service.py
@@ -1,0 +1,67 @@
+from app.services.songsterr import (
+    TABS_CDN_HOSTS,
+    TABS_PART_CDN_HOSTS,
+    TABS_STAGE_CDN_HOST,
+    _build_tab_candidate_urls,
+    _extract_search_records,
+)
+
+
+def test_extract_search_records_from_list():
+    payload = [{"songId": 1, "title": "Test"}]
+    records = _extract_search_records(payload)
+    assert records == payload
+
+
+def test_extract_search_records_from_records_wrapper():
+    payload = {"records": [{"songId": 1, "title": "Test"}], "total": 1}
+    records = _extract_search_records(payload)
+    assert records == payload["records"]
+
+
+def test_extract_search_records_from_results_wrapper():
+    payload = {"results": [{"songId": 1, "title": "Test"}]}
+    records = _extract_search_records(payload)
+    assert records == payload["results"]
+
+
+def test_extract_search_records_raises_for_invalid_shape():
+    payload = {"records": "not-a-list"}
+    try:
+        _extract_search_records(payload)
+    except ValueError as exc:
+        assert "Unexpected Songsterr search response format" in str(exc)
+    else:
+        assert False, "Expected ValueError for invalid search payload"
+
+
+def test_build_tab_candidate_urls_stage_image_uses_stage_host_first():
+    urls = _build_tab_candidate_urls(
+        song_id=1,
+        revision_id=2,
+        image="v0-foo-stage",
+        track_index=3,
+    )
+    assert urls[0] == f"https://{TABS_STAGE_CDN_HOST}.cloudfront.net/1/2/v0-foo-stage/3.json"
+    assert any(f"https://{host}.cloudfront.net/1/2/v0-foo-stage/3.json" in urls for host in TABS_CDN_HOSTS)
+
+
+def test_build_tab_candidate_urls_non_stage_image_uses_regular_hosts():
+    urls = _build_tab_candidate_urls(
+        song_id=1,
+        revision_id=2,
+        image="v0-foo",
+        track_index=3,
+    )
+    assert all(url.endswith("/1/2/v0-foo/3.json") for url in urls)
+    assert len(urls) == len(TABS_CDN_HOSTS)
+
+
+def test_build_tab_candidate_urls_without_image_uses_part_hosts():
+    urls = _build_tab_candidate_urls(
+        song_id=1,
+        revision_id=2,
+        image=None,
+        track_index=3,
+    )
+    assert urls == [f"https://{host}.cloudfront.net/part/2/3" for host in TABS_PART_CDN_HOSTS]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,12 +50,16 @@ function App() {
     chordProLoading,
     songViewMode,
     highlightedNotes,
+    selectedTuning,
+    customTuningNotes,
+    fetchTunings,
   } = useAppStore();
 
   // ============================================================================
   // Fretboard data (still uses hook for API fetch with loading/error)
   // ============================================================================
-  const { fretboardData, loading, error } = useFretboard();
+  const tuningNotes = customTuningNotes?.join(',');
+  const { fretboardData, loading, error } = useFretboard(selectedTuning, tuningNotes);
 
   // ============================================================================
   // Apply dark mode class on mount and sync with localStorage
@@ -70,13 +74,29 @@ function App() {
   }, [darkMode]);
 
   // ============================================================================
-  // Auto-fetch scale when in scale mode
+  // Fetch available tunings on mount
+  // ============================================================================
+  useEffect(() => { fetchTunings(); }, [fetchTunings]);
+
+  // ============================================================================
+  // Auto-fetch scale when in scale mode (re-fetches on tuning change)
   // ============================================================================
   useEffect(() => {
     if (appMode === 'scale') {
       fetchScale(selectedRoot, selectedMode);
     }
-  }, [appMode, selectedRoot, selectedMode, fetchScale]);
+  }, [appMode, selectedRoot, selectedMode, selectedTuning, customTuningNotes, fetchScale]);
+
+  // ============================================================================
+  // Re-fetch chord when tuning changes
+  // ============================================================================
+  useEffect(() => {
+    const { selectedChordRoot, selectedChordQuality } = useAppStore.getState();
+    if (appMode === 'chord' && selectedChordRoot && selectedChordQuality) {
+      fetchChord(selectedChordRoot, selectedChordQuality);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTuning, customTuningNotes]);
 
   // ============================================================================
   // Computed Values
@@ -152,7 +172,8 @@ function App() {
 
     try {
       // Fetch chord data directly without updating the store
-      const data = await apiClient.getChord(diatonicChord.root, diatonicChord.quality);
+      const { selectedTuning: t, customTuningNotes: cn } = useAppStore.getState();
+      const data = await apiClient.getChord(diatonicChord.root, diatonicChord.quality, t, cn?.join(','));
       setPopupState({
         chordData: data,
         position: { x: e.clientX, y: e.clientY },
@@ -286,7 +307,7 @@ function App() {
                       </div>
                     )}
                     {!tabLoading && !tabError && tabData && (
-                      <TabViewer tabData={tabData.tab_data} />
+                      <TabViewer tabData={tabData.tab_data} tuningNotes={fretboardData?.tuning_notes} />
                     )}
                   </>
                 ) : (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 import { Fretboard } from './components/Fretboard';
 import { ChordDiagramRow } from './components/ChordDiagram';
 import { ChordPopup } from './components/ChordPopup';
@@ -10,9 +10,11 @@ import { useFretboard } from './hooks';
 import { useAppStore } from './stores';
 import { apiClient } from './api/client';
 import type { DiatonicChord } from './types';
-import type { AgentAction } from './types/chat';
+import type { AgentAction, FretboardHighlightAction } from './types/chat';
 
 function App() {
+  const [agentHighlightKeyScopeActive, setAgentHighlightKeyScopeActive] = useState(false);
+
   // ============================================================================
   // Zustand Store - only what App.tsx needs directly
   // ============================================================================
@@ -43,6 +45,7 @@ function App() {
     resetChord,
     setChordData,
     sendMessage,
+    messages,
     selectedSong,
     tabData,
     tabLoading,
@@ -59,6 +62,13 @@ function App() {
     selectedTuning,
     customTuningNotes,
     fetchTunings,
+    agentHighlightGroups,
+    agentHighlightIndex,
+    agentHighlightVisible,
+    setAgentHighlights,
+    clearAgentHighlights,
+    nextAgentHighlight,
+    prevAgentHighlight,
   } = useAppStore();
 
   // ============================================================================
@@ -83,6 +93,56 @@ function App() {
   // Fetch available tunings on mount
   // ============================================================================
   useEffect(() => { fetchTunings(); }, [fetchTunings]);
+
+  useEffect(() => {
+    const updateScope = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) {
+        setAgentHighlightKeyScopeActive(false);
+        return;
+      }
+      setAgentHighlightKeyScopeActive(!!target.closest('[data-agent-highlight-scope="chat"]'));
+    };
+
+    const handlePointerDown = (event: PointerEvent) => updateScope(event.target);
+    const handleFocusIn = (event: FocusEvent) => updateScope(event.target);
+
+    window.addEventListener('pointerdown', handlePointerDown, true);
+    window.addEventListener('focusin', handleFocusIn);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true);
+      window.removeEventListener('focusin', handleFocusIn);
+    };
+  }, []);
+
+  // Rehydrate the latest assistant fretboard highlight from persisted chat history
+  // after a full page refresh. This keeps the overlay controls in chat aligned
+  // with the visible assistant message without replaying all agent actions.
+  useEffect(() => {
+    const latestHighlightMessage = [...messages].reverse().find((message) =>
+      message.role === 'assistant'
+      && message.actions?.some(
+        (action): action is FretboardHighlightAction =>
+          action.type === 'fretboard.highlight' && action.groups.length > 0,
+      ),
+    );
+
+    if (!latestHighlightMessage) {
+      clearAgentHighlights();
+      return;
+    }
+
+    const highlightAction = latestHighlightMessage.actions?.find(
+      (action): action is FretboardHighlightAction =>
+        action.type === 'fretboard.highlight' && action.groups.length > 0,
+    );
+
+    if (highlightAction) {
+      setAgentHighlights(highlightAction.groups, latestHighlightMessage.id);
+    }
+    // Intentionally mount-only: we want refresh rehydration, but we should not
+    // re-enable highlights after the user explicitly clears or hides them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ============================================================================
   // Auto-fetch scale when in scale mode (re-fetches on tuning change)
@@ -124,8 +184,8 @@ function App() {
     return new Set(scaleData.scale_notes);
   }, [appMode, scaleData]);
 
-  // Determine which chord data to show on fretboard
-  const fretboardChordData = appMode === 'song' ? null : chordData;
+  // Determine which chord data to show on fretboard (suppress when agent highlights are active)
+  const fretboardChordData = (appMode === 'song' || agentHighlightVisible) ? null : chordData;
   const fretboardScalePositions = (appMode === 'scale' || (appMode === 'chord' && showScaleInChordMode))
     ? (scaleData?.positions ?? [])
     : [];
@@ -201,7 +261,8 @@ function App() {
     clearChord();
     resetScale();
     resetChord();
-  }, [clearScale, clearChord, resetScale, resetChord]);
+    clearAgentHighlights();
+  }, [clearScale, clearChord, resetScale, resetChord, clearAgentHighlights]);
 
   // Handle chat chord click
   const handleChatChordClick = useCallback(async (
@@ -247,8 +308,63 @@ function App() {
     fetchScale(root, mode);
   }, [setAppMode, fetchScale]);
 
+  // Derive active agent highlight group for fretboard (only when visible)
+  const agentHighlightGroup = agentHighlightVisible && agentHighlightGroups
+    ? agentHighlightGroups[agentHighlightIndex] ?? null
+    : null;
+
+  useEffect(() => {
+    if (
+      !agentHighlightKeyScopeActive ||
+      !agentHighlightVisible ||
+      !agentHighlightGroups ||
+      agentHighlightGroups.length <= 1
+    ) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tagName = target.tagName;
+        if (
+          target.isContentEditable ||
+          tagName === 'INPUT' ||
+          tagName === 'TEXTAREA' ||
+          tagName === 'SELECT'
+        ) {
+          return;
+        }
+      }
+
+      // In song mode, TabViewer already owns arrow-key navigation.
+      if (appMode === 'song') return;
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        prevAgentHighlight();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        nextAgentHighlight();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    agentHighlightGroups,
+    agentHighlightKeyScopeActive,
+    agentHighlightVisible,
+    appMode,
+    nextAgentHighlight,
+    prevAgentHighlight,
+  ]);
+
   // Handle chat send with visualization
-  const executeAgentActions = useCallback(async (actions: AgentAction[]) => {
+  const executeAgentActions = useCallback(async (actions: AgentAction[], messageId?: string) => {
     const currentMode = useAppStore.getState().appMode;
 
     for (const action of actions) {
@@ -291,6 +407,10 @@ function App() {
           focusMeasureBeat(action.measure_index, action.beat_index);
           continue;
         }
+        if (action.type === 'fretboard.highlight') {
+          if (messageId) setAgentHighlights(action.groups, messageId);
+          continue;
+        }
         console.warn('Unknown agent action type:', action);
       } catch (err) {
         console.error('Failed to execute agent action:', action, err);
@@ -303,6 +423,7 @@ function App() {
     searchSongs,
     selectSongById,
     selectTrack,
+    setAgentHighlights,
     setAppMode,
     setSongViewMode,
   ]);
@@ -311,7 +432,7 @@ function App() {
     const response = await sendMessage(message);
 
     if (response?.actions?.length) {
-      await executeAgentActions(response.actions);
+      await executeAgentActions(response.actions, response.id);
       return;
     }
 
@@ -458,6 +579,7 @@ function App() {
                 clickableScaleNotes={clickableScaleNotes}
                 darkMode={darkMode}
                 highlightedNotes={appMode === 'song' ? highlightedNotes : []}
+                agentHighlightGroup={agentHighlightGroup}
               />
             )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -461,13 +461,15 @@ function App() {
 
         {/* Main Content Area */}
         <div className="flex-1 flex flex-col overflow-hidden" style={{ backgroundColor: 'var(--main-content-bg)' }}>
-          {/* Control Bar - uses Zustand for state, only needs action handlers */}
-          <ControlBar
-            onScaleSelect={handleScaleSelect}
-            onDiatonicChordClick={handleDiatonicChordClick}
-            onDirectChordSelect={handleDirectChordSelect}
-            onClearAll={handleClearAll}
-          />
+          {/* Control Bar - hide empty song panel before a song is selected */}
+          {!(appMode === 'song' && !selectedSong) && (
+            <ControlBar
+              onScaleSelect={handleScaleSelect}
+              onDiatonicChordClick={handleDiatonicChordClick}
+              onDirectChordSelect={handleDirectChordSelect}
+              onClearAll={handleClearAll}
+            />
+          )}
 
           {/* Scrollable Content */}
           <main className="flex-1 overflow-y-auto p-3 md:p-6 space-y-4 pb-20 md:pb-6" style={{ backgroundColor: 'var(--main-content-bg)' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,9 @@ import { useEffect, useMemo, useCallback } from 'react';
 import { Fretboard } from './components/Fretboard';
 import { ChordDiagramRow } from './components/ChordDiagram';
 import { ChordPopup } from './components/ChordPopup';
+import { SongSearch } from './components/SongSearch';
+import { TabViewer } from './components/TabViewer';
+import { ChordProView } from './components/ChordProView';
 import { Header, ChatSidebar, MobileChatSheet, ControlBar } from './components/layout';
 import { useFretboard } from './hooks';
 import { useAppStore } from './stores';
@@ -39,6 +42,14 @@ function App() {
     resetChord,
     setChordData,
     sendMessage,
+    selectedSong,
+    tabData,
+    tabLoading,
+    tabError,
+    chordProData,
+    chordProLoading,
+    songViewMode,
+    highlightedNotes,
   } = useAppStore();
 
   // ============================================================================
@@ -88,8 +99,8 @@ function App() {
   }, [appMode, scaleData]);
 
   // Determine which chord data to show on fretboard
-  const fretboardChordData = chordData;
-  const fretboardScalePositions = (appMode === 'scale' || showScaleInChordMode)
+  const fretboardChordData = appMode === 'song' ? null : chordData;
+  const fretboardScalePositions = (appMode === 'scale' || (appMode === 'chord' && showScaleInChordMode))
     ? (scaleData?.positions ?? [])
     : [];
 
@@ -248,8 +259,65 @@ function App() {
 
           {/* Scrollable Content */}
           <main className="flex-1 overflow-y-auto p-3 md:p-6 space-y-4 pb-20 md:pb-6" style={{ backgroundColor: 'var(--main-content-bg)' }}>
+            {/* Song mode content */}
+            {appMode === 'song' && !selectedSong && (
+              <SongSearch />
+            )}
+
+            {appMode === 'song' && selectedSong && (
+              <>
+                {songViewMode === 'tab' ? (
+                  <>
+                    {tabLoading && (
+                      <div className="flex items-center justify-center py-8 text-sm" style={{ color: 'var(--text-muted)' }}>
+                        Loading tab...
+                      </div>
+                    )}
+                    {!tabLoading && tabError && (
+                      <div
+                        className="rounded-lg p-4 border text-sm"
+                        style={{
+                          borderColor: '#b91c1c',
+                          backgroundColor: 'rgba(239,68,68,0.1)',
+                          color: '#b91c1c',
+                        }}
+                      >
+                        {tabError}
+                      </div>
+                    )}
+                    {!tabLoading && !tabError && tabData && (
+                      <TabViewer tabData={tabData.tab_data} />
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {chordProLoading && (
+                      <div className="flex items-center justify-center py-8 text-sm" style={{ color: 'var(--text-muted)' }}>
+                        Loading chords...
+                      </div>
+                    )}
+                    {!chordProLoading && chordProData && (
+                      <ChordProView chordpro={chordProData.chordpro} />
+                    )}
+                    {!chordProLoading && !chordProData && (
+                      <div
+                        className="rounded-lg p-4 border text-sm"
+                        style={{
+                          borderColor: 'var(--border-primary)',
+                          backgroundColor: 'var(--card-bg)',
+                          color: 'var(--text-muted)',
+                        }}
+                      >
+                        No chord data available for this song.
+                      </div>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+
             {/* Chord Diagrams */}
-            {fretboardChordData && (
+            {appMode !== 'song' && fretboardChordData && (
               <ChordDiagramRow
                 voicings={fretboardChordData.voicings}
                 activeVoicings={activeVoicings}
@@ -298,6 +366,7 @@ function App() {
                 onScaleNoteClick={handleScaleNoteClick}
                 clickableScaleNotes={clickableScaleNotes}
                 darkMode={darkMode}
+                highlightedNotes={appMode === 'song' ? highlightedNotes : []}
               />
             )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { useFretboard } from './hooks';
 import { useAppStore } from './stores';
 import { apiClient } from './api/client';
 import type { DiatonicChord } from './types';
+import type { AgentAction } from './types/chat';
 
 function App() {
   // ============================================================================
@@ -50,6 +51,11 @@ function App() {
     chordProLoading,
     songViewMode,
     highlightedNotes,
+    searchSongs,
+    selectSongById,
+    selectTrack,
+    focusMeasureBeat,
+    setSongViewMode,
     selectedTuning,
     customTuningNotes,
     fetchTunings,
@@ -242,17 +248,81 @@ function App() {
   }, [setAppMode, fetchScale]);
 
   // Handle chat send with visualization
+  const executeAgentActions = useCallback(async (actions: AgentAction[]) => {
+    const currentMode = useAppStore.getState().appMode;
+
+    for (const action of actions) {
+      try {
+        if (action.type === 'theory.show_chord') {
+          // In song mode, skip auto-switching — let the user click pills instead
+          if (currentMode === 'song') continue;
+          await handleChatChordClick(`${action.root} ${action.quality}`, {
+            root: action.root,
+            quality: action.quality,
+          });
+          continue;
+        }
+        if (action.type === 'theory.show_scale') {
+          if (currentMode === 'song') continue;
+          await handleChatScaleClick(`${action.root} ${action.mode}`, {
+            root: action.root,
+            mode: action.mode,
+          });
+          continue;
+        }
+        if (action.type === 'song.search') {
+          setAppMode('song');
+          await searchSongs(action.query);
+          continue;
+        }
+        if (action.type === 'song.select') {
+          setAppMode('song');
+          await selectSongById(action.song_id);
+          continue;
+        }
+        if (action.type === 'song.track.select') {
+          setAppMode('song');
+          await selectTrack(action.track_index);
+          continue;
+        }
+        if (action.type === 'song.measure.focus') {
+          setAppMode('song');
+          setSongViewMode('tab');
+          focusMeasureBeat(action.measure_index, action.beat_index);
+          continue;
+        }
+        console.warn('Unknown agent action type:', action);
+      } catch (err) {
+        console.error('Failed to execute agent action:', action, err);
+      }
+    }
+  }, [
+    focusMeasureBeat,
+    handleChatChordClick,
+    handleChatScaleClick,
+    searchSongs,
+    selectSongById,
+    selectTrack,
+    setAppMode,
+    setSongViewMode,
+  ]);
+
   const handleChatSend = useCallback(async (message: string) => {
     const response = await sendMessage(message);
-    
-    // If visualizations requested and we have parsed chord requests, show the first one
+
+    if (response?.actions?.length) {
+      await executeAgentActions(response.actions);
+      return;
+    }
+
+    // Backward compatibility fallback for older responses with no actions[]
     if (response?.visualizations && response.apiRequests?.chords?.length) {
       const firstChordRequest = response.apiRequests.chords[0];
       if (response.chordChoices?.[0]) {
         await handleChatChordClick(response.chordChoices[0], firstChordRequest);
       }
     }
-  }, [sendMessage, handleChatChordClick]);
+  }, [sendMessage, executeAgentActions, handleChatChordClick]);
 
   return (
     <div className="h-screen flex flex-col overflow-hidden" style={{ backgroundColor: 'var(--bg-secondary)' }}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -117,8 +117,10 @@ class ApiClient {
     throw new Error('Stream ended without an answer event');
   }
 
-  async getFretboard(tuning: string = 'standard'): Promise<FretboardResponse> {
-    return this.fetch<FretboardResponse>(`/fretboard?tuning=${tuning}`);
+  async getFretboard(tuning: string = 'standard', tuningNotes?: string): Promise<FretboardResponse> {
+    let url = `/fretboard?tuning=${tuning}`;
+    if (tuningNotes) url += `&tuning_notes=${encodeURIComponent(tuningNotes)}`;
+    return this.fetch<FretboardResponse>(url);
   }
 
   async getTunings(): Promise<TuningsResponse> {
@@ -129,16 +131,20 @@ class ApiClient {
     return this.fetch<ScalesListResponse>('/scales');
   }
 
-  async getScale(root: string, mode: string, tuning: string = 'standard'): Promise<ScaleResponse> {
-    return this.fetch<ScaleResponse>(`/scales/${encodeURIComponent(root)}/${encodeURIComponent(mode)}?tuning=${tuning}`);
+  async getScale(root: string, mode: string, tuning: string = 'standard', tuningNotes?: string): Promise<ScaleResponse> {
+    let url = `/scales/${encodeURIComponent(root)}/${encodeURIComponent(mode)}?tuning=${tuning}`;
+    if (tuningNotes) url += `&tuning_notes=${encodeURIComponent(tuningNotes)}`;
+    return this.fetch<ScaleResponse>(url);
   }
 
   async getChordQualities(): Promise<ChordQualitiesResponse> {
     return this.fetch<ChordQualitiesResponse>('/chords/qualities');
   }
 
-  async getChord(root: string, quality: string): Promise<ChordResponse> {
-    return this.fetch<ChordResponse>(`/chords/${encodeURIComponent(root)}/${encodeURIComponent(quality)}`);
+  async getChord(root: string, quality: string, tuning: string = 'standard', tuningNotes?: string): Promise<ChordResponse> {
+    let url = `/chords/${encodeURIComponent(root)}/${encodeURIComponent(quality)}?tuning=${tuning}`;
+    if (tuningNotes) url += `&tuning_notes=${encodeURIComponent(tuningNotes)}`;
+    return this.fetch<ChordResponse>(url);
   }
 
   async streamChat(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import type { FretboardResponse, TuningsResponse, ScalesListResponse, ScaleResponse, ChordResponse, ChordQualitiesResponse, SongSearchResponse, SongTracksResponse, TabDataResponse, ChordProResponse } from '../types';
-import type { AgentRequest, AgentResponse, ChatMessage, ResumeRequest, SseEvent } from '../types/chat';
+import type { AgentRequest, AgentResponse, ChatMessage, ResumeRequest, SseEvent, UiContext } from '../types/chat';
 
 // Read base URL from Vite env at build-time (VITE_API_BASE_URL).
 // Use a relative URL by default so the browser calls the same origin (/api) and
@@ -11,6 +11,7 @@ export function nodeLabel(node: string): string {
   const labels: Record<string, string> = {
     prepare_question: 'Preparing...',
     clarify:          'Thinking...',
+    clarify_input:    'Need clarification...',
     generate_answer:  'Generating answer...',
   };
   return labels[node] ?? 'Thinking...';
@@ -85,7 +86,22 @@ class ApiClient {
     });
 
     if (!response.ok) {
-      throw new Error(`API error: ${response.status} ${response.statusText}`);
+      let detail = `API error: ${response.status} ${response.statusText}`;
+      let code: string | undefined;
+      let threadId: string | undefined;
+      try {
+        const data = await response.json();
+        if (typeof data?.detail === 'string') detail = data.detail;
+        if (typeof data?.detail?.detail === 'string') detail = data.detail.detail;
+        if (typeof data?.detail?.code === 'string') code = data.detail.code;
+        if (typeof data?.detail?.thread_id === 'string') threadId = data.detail.thread_id;
+      } catch {
+        // ignore JSON parse errors
+      }
+      const err = new Error(detail) as Error & { code?: string; thread_id?: string };
+      err.code = code;
+      err.thread_id = threadId;
+      throw err;
     }
     if (!response.body) {
       throw new Error('No response body from stream endpoint');
@@ -109,7 +125,10 @@ class ApiClient {
       } else if (event.event === 'answer') {
         return event.data;
       } else if (event.event === 'error') {
-        throw new Error(event.data.detail);
+        const err = new Error(event.data.detail) as Error & { code?: string; thread_id?: string };
+        err.code = event.data.code;
+        err.thread_id = event.data.thread_id;
+        throw err;
       }
       // 'done' — stream finished normally after 'answer', nothing to do
     }
@@ -149,18 +168,31 @@ class ApiClient {
 
   async streamChat(
     message: string,
-    conversationHistory: ChatMessage[] = [],
     threadId: string = 'default',
+    uiContext?: UiContext,
+    options?: {
+      bootstrapHistory?: ChatMessage[];
+      requireExistingThread?: boolean;
+      deprecatedConversationHistory?: ChatMessage[];
+    },
     onStatus?: (node: string) => void,
     onToken?: (text: string) => void,
   ): Promise<AgentResponse> {
+    const bootstrapHistory = options?.bootstrapHistory ?? [];
+    const deprecatedConversationHistory = options?.deprecatedConversationHistory ?? [];
     const request: AgentRequest = {
       message,
-      conversation_history: conversationHistory.map(msg => ({
+      thread_id: threadId,
+      ui_context: uiContext,
+      require_existing_thread: options?.requireExistingThread ?? false,
+      bootstrap_history: bootstrapHistory.map(msg => ({
         role: msg.role,
         content: msg.content,
       })),
-      thread_id: threadId,
+      conversation_history: deprecatedConversationHistory.map(msg => ({
+        role: msg.role,
+        content: msg.content,
+      })),
     };
     return this._runStream('/agent/chat/stream', request, onStatus, onToken);
   }
@@ -168,10 +200,11 @@ class ApiClient {
   async streamResume(
     response: string,
     threadId: string = 'default',
+    uiContext?: UiContext,
     onStatus?: (node: string) => void,
     onToken?: (text: string) => void,
   ): Promise<AgentResponse> {
-    const request: ResumeRequest = { response, thread_id: threadId };
+    const request: ResumeRequest = { response, thread_id: threadId, ui_context: uiContext };
     return this._runStream('/agent/resume/stream', request, onStatus, onToken);
   }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { FretboardResponse, TuningsResponse, ScalesListResponse, ScaleResponse, ChordResponse, ChordQualitiesResponse } from '../types';
+import type { FretboardResponse, TuningsResponse, ScalesListResponse, ScaleResponse, ChordResponse, ChordQualitiesResponse, SongSearchResponse, SongTracksResponse, TabDataResponse, ChordProResponse } from '../types';
 import type { AgentRequest, AgentResponse, ChatMessage, ResumeRequest, SseEvent } from '../types/chat';
 
 // Read base URL from Vite env at build-time (VITE_API_BASE_URL).
@@ -167,6 +167,24 @@ class ApiClient {
   ): Promise<AgentResponse> {
     const request: ResumeRequest = { response, thread_id: threadId };
     return this._runStream('/agent/resume/stream', request, onStatus, onToken);
+  }
+
+  // --- Song endpoints ---
+
+  async searchSongs(query: string): Promise<SongSearchResponse> {
+    return this.fetch<SongSearchResponse>(`/songs/search?q=${encodeURIComponent(query)}`);
+  }
+
+  async getSongTracks(songId: number): Promise<SongTracksResponse> {
+    return this.fetch<SongTracksResponse>(`/songs/${songId}/tracks`);
+  }
+
+  async getTabData(songId: number, trackIndex: number = 0): Promise<TabDataResponse> {
+    return this.fetch<TabDataResponse>(`/songs/${songId}/tab?track=${trackIndex}`);
+  }
+
+  async getChordPro(songId: number): Promise<ChordProResponse> {
+    return this.fetch<ChordProResponse>(`/songs/${songId}/chords`);
   }
 }
 

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ChatPill } from './ChatPill'
 import type { ChatMessage as ChatMessageType } from '../../types/chat';
+import { useAppStore } from '../../stores';
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -17,6 +18,17 @@ interface ChatMessageProps {
 
 export function ChatMessage({ message, onChordClick, onScaleClick, darkMode = false, selectedChordRoot = null, selectedChordQuality = null, selectedScaleRoot = null, selectedScaleMode = null }: ChatMessageProps) {
   const isUser = message.role === 'user';
+  const {
+    agentHighlightGroups,
+    agentHighlightIndex,
+    agentHighlightVisible,
+    agentHighlightMessageId,
+    nextAgentHighlight,
+    prevAgentHighlight,
+    toggleAgentHighlightVisible,
+  } = useAppStore();
+
+  const isActiveHighlightMessage = !isUser && message.id === agentHighlightMessageId && !!agentHighlightGroups;
 
   // Find the API request for a chord by index
   const getChordApiRequest = (index: number) => {
@@ -84,6 +96,44 @@ export function ChatMessage({ message, onChordClick, onScaleClick, darkMode = fa
                   : false
               }
             />
+          </div>
+        )}
+
+        {/* Agent fretboard highlight controls */}
+        {isActiveHighlightMessage && agentHighlightGroups && (
+          <div className="mt-3 pt-2.5 border-t" style={{ borderColor: 'var(--border-primary)' }}>
+            <p className="text-xs mb-2 font-medium" style={{ color: 'var(--text-muted)' }}>Fretboard highlight:</p>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={prevAgentHighlight}
+                className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
+                style={{ backgroundColor: 'var(--bg-hover)', color: 'var(--text-secondary)' }}
+                aria-label="Previous"
+              >‹</button>
+              <span className="text-xs font-medium flex-1 text-center" style={{ color: 'var(--text-primary)' }}>
+                {agentHighlightGroups[agentHighlightIndex]?.name}
+                {agentHighlightGroups.length > 1 && (
+                  <span className="ml-1" style={{ color: 'var(--text-muted)' }}>
+                    ({agentHighlightIndex + 1}/{agentHighlightGroups.length})
+                  </span>
+                )}
+              </span>
+              <button
+                onClick={nextAgentHighlight}
+                className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
+                style={{ backgroundColor: 'var(--bg-hover)', color: 'var(--text-secondary)' }}
+                aria-label="Next"
+              >›</button>
+              <button
+                onClick={toggleAgentHighlightVisible}
+                className="text-xs px-2 py-0.5 rounded transition-colors"
+                style={{
+                  backgroundColor: agentHighlightVisible ? 'var(--accent-500)' : 'var(--bg-hover)',
+                  color: agentHighlightVisible ? 'white' : 'var(--text-muted)',
+                }}
+                aria-label={agentHighlightVisible ? 'Hide highlights' : 'Show highlights'}
+              >{agentHighlightVisible ? 'Hide' : 'Show'}</button>
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/Chat/ChatPanel.tsx
+++ b/frontend/src/components/Chat/ChatPanel.tsx
@@ -50,6 +50,7 @@ export function ChatPanel({
   if (isCollapsed) {
     return (
       <div
+        data-agent-highlight-scope="chat"
         className="flex flex-col h-full font-sans border-r items-center justify-start py-2"
         style={{
           backgroundColor: 'var(--chat-bg)',
@@ -73,6 +74,7 @@ export function ChatPanel({
 
   return (
     <div 
+      data-agent-highlight-scope="chat"
       className="flex flex-col h-full font-sans border-r"
       style={{ 
         backgroundColor: 'var(--chat-bg)',

--- a/frontend/src/components/ChordProView/ChordProView.tsx
+++ b/frontend/src/components/ChordProView/ChordProView.tsx
@@ -1,0 +1,133 @@
+import { useMemo } from 'react';
+
+interface ChordProViewProps {
+  chordpro: string;
+}
+
+type ParsedLine =
+  | { kind: 'blank' }
+  | { kind: 'section'; text: string }
+  | { kind: 'meta'; key: string; value: string }
+  | { kind: 'lyrics'; chords?: string; lyrics: string };
+
+function parseChordPro(chordpro: string): ParsedLine[] {
+  const parsed: ParsedLine[] = [];
+  const directiveRegex = /^\{(\w+):\s*(.+)\}$/;
+  const chordTokenRegex = /(\[[^\]]+\])/;
+
+  for (const raw of chordpro.split('\n')) {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      parsed.push({ kind: 'blank' });
+      continue;
+    }
+
+    const directive = trimmed.match(directiveRegex);
+    if (directive) {
+      const [, key, value] = directive;
+      if (key.toLowerCase() === 'section') {
+        parsed.push({ kind: 'section', text: value });
+      } else {
+        parsed.push({ kind: 'meta', key, value });
+      }
+      continue;
+    }
+
+    let chordLine = '';
+    let lyricLine = '';
+    let lyricPos = 0;
+
+    for (const part of raw.split(chordTokenRegex)) {
+      const isChord = part.startsWith('[') && part.endsWith(']');
+      if (isChord) {
+        const chordName = part.slice(1, -1);
+        while (chordLine.length < lyricPos) chordLine += ' ';
+        chordLine += `${chordName} `;
+      } else {
+        lyricLine += part;
+        lyricPos += part.length;
+      }
+    }
+
+    parsed.push({
+      kind: 'lyrics',
+      chords: chordLine.trimEnd() || undefined,
+      lyrics: lyricLine,
+    });
+  }
+
+  return parsed;
+}
+
+export function ChordProView({ chordpro }: ChordProViewProps) {
+  const lines = useMemo(() => parseChordPro(chordpro), [chordpro]);
+
+  return (
+    <section
+      className="rounded-xl border p-3 md:p-4"
+      style={{
+        borderColor: 'var(--border-primary)',
+        backgroundColor: 'var(--card-bg)',
+        boxShadow: 'var(--shadow-sm)',
+      }}
+    >
+      <div className="mb-3">
+        <h3 className="text-sm md:text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
+          ChordPro View
+        </h3>
+      </div>
+
+      <div
+        className="font-mono text-[12px] leading-5 rounded-lg border p-3 max-h-[480px] overflow-auto"
+        style={{
+          borderColor: 'var(--border-primary)',
+          backgroundColor: 'var(--bg-secondary)',
+          color: 'var(--text-primary)',
+        }}
+      >
+        {lines.map((line, idx) => {
+          if (line.kind === 'blank') {
+            return <div key={idx} className="h-3" />;
+          }
+
+          if (line.kind === 'section') {
+            return (
+              <div key={idx} className="py-1">
+                <span
+                  className="inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold border"
+                  style={{
+                    borderColor: 'var(--accent-600)',
+                    color: 'var(--accent-600)',
+                    backgroundColor: 'rgba(16,185,129,0.1)',
+                  }}
+                >
+                  {line.text}
+                </span>
+              </div>
+            );
+          }
+
+          if (line.kind === 'meta') {
+            return (
+              <div key={idx} className="text-[11px] pb-1" style={{ color: 'var(--text-muted)' }}>
+                {line.key}: {line.value}
+              </div>
+            );
+          }
+
+          return (
+            <div key={idx} className="pb-1">
+              {line.chords && (
+                <div className="whitespace-pre" style={{ color: 'var(--accent-600)' }}>
+                  {line.chords}
+                </div>
+              )}
+              <div className="whitespace-pre">{line.lyrics}</div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/ChordProView/index.ts
+++ b/frontend/src/components/ChordProView/index.ts
@@ -1,0 +1,2 @@
+export { ChordProView } from './ChordProView';
+

--- a/frontend/src/components/ChordSelector/ChordSelector.tsx
+++ b/frontend/src/components/ChordSelector/ChordSelector.tsx
@@ -148,7 +148,7 @@ export function ChordSelector({ selectedRoot, selectedQuality, onSelect, darkMod
   const chordName = `${root}${selectedExtensionOption?.suffix ?? ''}`;
 
   return (
-    <div className="flex flex-wrap items-center gap-3 md:gap-6">
+    <div className="flex flex-wrap items-center gap-3 md:gap-4">
       {/* Root selector */}
       <div className="flex flex-col gap-1">
         <label className="text-[10px] md:text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>Root</label>

--- a/frontend/src/components/ChordSelector/ChordSelector.tsx
+++ b/frontend/src/components/ChordSelector/ChordSelector.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-const ROOTS = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const ROOTS = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
 
 type BaseQualityValue = 'major' | 'minor' | 'diminished' | 'augmented' | 'sus2' | 'sus4';
 type ExtensionValue = 'none' | '6' | '7' | 'dom7' | 'add9' | '9' | 'maj9' | 'm7b5';

--- a/frontend/src/components/Fretboard/Fretboard.tsx
+++ b/frontend/src/components/Fretboard/Fretboard.tsx
@@ -1,4 +1,5 @@
 import type { NotePosition, ScaleNotePosition, ChordVoicing, HighlightedNote } from '../../types';
+import type { FretboardHighlightGroup } from '../../types/chat';
 import { FretboardHeader, FretMarkersRow } from './FretboardHeader';
 import { StringRow } from './StringRow';
 import { getVoicingColor } from '../../constants/colors';
@@ -19,6 +20,7 @@ interface FretboardProps {
   onScaleNoteClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   clickableScaleNotes?: Set<string>;
   highlightedNotes?: HighlightedNote[];
+  agentHighlightGroup?: FretboardHighlightGroup | null;
   darkMode?: boolean;
 }
 
@@ -33,10 +35,13 @@ export function Fretboard({
   onScaleNoteClick,
   clickableScaleNotes,
   highlightedNotes = [],
+  agentHighlightGroup = null,
   darkMode = false,
 }: FretboardProps) {
   const hasScale = scalePositions.length > 0;
   const hasChords = chordVoicings.length > 0;
+  const hasAgentHighlight = !!agentHighlightGroup && agentHighlightGroup.positions.length > 0;
+  const hasOverlay = hasChords || hasAgentHighlight;
   const visibleVoicings = (activeVoicings.length > 0
     ? chordVoicings.filter((v) => activeVoicings.includes(v.label))
     : chordVoicings
@@ -59,6 +64,12 @@ export function Fretboard({
 
         {/* Legend - scrollable on mobile */}
         <div className="flex items-center gap-2 md:gap-4 text-sm overflow-x-auto pb-1 -mb-1 pl-1 pt-1">
+          {hasAgentHighlight && (
+            <div className="flex items-center gap-1 md:gap-1.5 flex-shrink-0">
+              <div className="w-3 h-3 md:w-4 md:h-4 rounded-full ring-2 ring-violet-400" style={{ backgroundColor: '#7c3aed' }} />
+              <span className="text-[10px] md:text-xs whitespace-nowrap" style={{ color: 'var(--text-muted)' }}>{agentHighlightGroup!.name}</span>
+            </div>
+          )}
           {hasChords ? (
             <>
               <div className="flex items-center gap-1 md:gap-1.5 flex-shrink-0">
@@ -144,8 +155,10 @@ export function Fretboard({
                 onNoteClick={onScaleNoteClick}
                 clickableNotes={clickableScaleNotes}
                 highlightedNotes={highlightedNotes}
+                agentHighlightPositions={agentHighlightGroup?.positions}
+                hasAgentHighlightLayer={hasAgentHighlight}
                 darkMode={darkMode}
-                hasChordOverlay={hasChords}
+                hasChordOverlay={hasOverlay}
               />
             ))}
           </div>

--- a/frontend/src/components/Fretboard/Fretboard.tsx
+++ b/frontend/src/components/Fretboard/Fretboard.tsx
@@ -1,4 +1,4 @@
-import type { NotePosition, ScaleNotePosition, ChordVoicing } from '../../types';
+import type { NotePosition, ScaleNotePosition, ChordVoicing, HighlightedNote } from '../../types';
 import { FretboardHeader, FretMarkersRow } from './FretboardHeader';
 import { StringRow } from './StringRow';
 import { getVoicingColor } from '../../constants/colors';
@@ -16,6 +16,7 @@ interface FretboardProps {
   displayMode?: 'notes' | 'intervals';
   onScaleNoteClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   clickableScaleNotes?: Set<string>;
+  highlightedNotes?: HighlightedNote[];
   darkMode?: boolean;
 }
 
@@ -29,6 +30,7 @@ export function Fretboard({
   displayMode = 'notes',
   onScaleNoteClick,
   clickableScaleNotes,
+  highlightedNotes = [],
   darkMode = false,
 }: FretboardProps) {
   const hasScale = scalePositions.length > 0;
@@ -139,6 +141,7 @@ export function Fretboard({
                 displayMode={displayMode}
                 onNoteClick={onScaleNoteClick}
                 clickableNotes={clickableScaleNotes}
+                highlightedNotes={highlightedNotes}
                 darkMode={darkMode}
                 hasChordOverlay={hasChords}
               />

--- a/frontend/src/components/Fretboard/Fretboard.tsx
+++ b/frontend/src/components/Fretboard/Fretboard.tsx
@@ -3,8 +3,10 @@ import { FretboardHeader, FretMarkersRow } from './FretboardHeader';
 import { StringRow } from './StringRow';
 import { getVoicingColor } from '../../constants/colors';
 
-// String names from high to low (string 1 to string 6)
-const STRING_NAMES = ['e', 'B', 'G', 'D', 'A', 'E'];
+// Derive string labels from tuning notes: string 1 (high) is lowercase, rest uppercase
+function tuningToStringNames(tuningNotes: string[]): string[] {
+  return tuningNotes.map((note, i) => (i === 0 ? note.toLowerCase() : note));
+}
 
 interface FretboardProps {
   strings: NotePosition[][];
@@ -133,7 +135,7 @@ export function Fretboard({
               <StringRow
                 key={idx}
                 stringNumber={idx + 1}
-                stringName={STRING_NAMES[idx]}
+                stringName={tuningToStringNames(tuningNotes)[idx]}
                 notes={stringNotes}
                 scalePositions={scalePositions}
                 chordVoicings={chordVoicings}

--- a/frontend/src/components/Fretboard/NoteCell.tsx
+++ b/frontend/src/components/Fretboard/NoteCell.tsx
@@ -14,6 +14,7 @@ interface NoteCellProps {
   hasChordOverlay?: boolean;
   onClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   isClickable?: boolean;
+  isHighlighted?: boolean;
   darkMode?: boolean;
 }
 
@@ -31,11 +32,16 @@ export function NoteCell({
   hasChordOverlay = false,
   onClick,
   isClickable = false,
+  isHighlighted = false,
   darkMode = false,
 }: NoteCellProps) {
   const voicingColor = voicingLabel ? getVoicingColor(voicingLabel) : null;
 
   const getColorClasses = () => {
+    if (isHighlighted) {
+      return 'bg-amber-400 text-gray-900 ring-2 ring-amber-400 animate-pulse';
+    }
+
     if (voicingLabel) {
       if (isChordRoot) {
         return darkMode
@@ -59,6 +65,9 @@ export function NoteCell({
   };
 
   const getRingStyle = (): React.CSSProperties => {
+    if (isHighlighted) {
+      return {};
+    }
     if (voicingLabel && isChordRoot) {
       return { '--tw-ring-color': 'var(--accent-400)' } as React.CSSProperties;
     }
@@ -66,6 +75,8 @@ export function NoteCell({
   };
 
   const getScaleNoteStyle = (): React.CSSProperties => {
+    if (isHighlighted) return {};
+
     if (isInScale && !isRoot && !voicingLabel) {
       if (hasChordOverlay) {
         return {
@@ -83,7 +94,7 @@ export function NoteCell({
   };
 
   const displayText = displayMode === 'intervals' && degreeLabel ? degreeLabel : note;
-  const isDimmed = !isInScale && !isRoot && !voicingLabel;
+  const isDimmed = !isHighlighted && !isInScale && !isRoot && !voicingLabel;
 
   const handleClick = (e: React.MouseEvent) => {
     if (onClick && isClickable) {
@@ -128,7 +139,7 @@ export function NoteCell({
             color: darkMode ? '#94a3b8' : '#9ca3af'
           } : {})
         }}
-        title={`${note} - Fret ${fret}${degreeLabel ? ` (${degreeLabel})` : ''}${isClickable ? ' (click for chord)' : ''}`}
+        title={`${note} - Fret ${fret}${degreeLabel ? ` (${degreeLabel})` : ''}${isHighlighted ? ' (highlighted from tab beat)' : ''}${isClickable ? ' (click for chord)' : ''}`}
       >
         {displayText}
       </button>

--- a/frontend/src/components/Fretboard/NoteCell.tsx
+++ b/frontend/src/components/Fretboard/NoteCell.tsx
@@ -15,6 +15,8 @@ interface NoteCellProps {
   onClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   isClickable?: boolean;
   isHighlighted?: boolean;
+  isAgentHighlighted?: boolean;
+  hasAgentHighlightLayer?: boolean;
   darkMode?: boolean;
 }
 
@@ -33,11 +35,17 @@ export function NoteCell({
   onClick,
   isClickable = false,
   isHighlighted = false,
+  isAgentHighlighted = false,
+  hasAgentHighlightLayer = false,
   darkMode = false,
 }: NoteCellProps) {
   const voicingColor = voicingLabel ? getVoicingColor(voicingLabel) : null;
 
   const getColorClasses = () => {
+    if (isAgentHighlighted) {
+      return 'ring-2 ring-violet-400 text-white';
+    }
+
     if (isHighlighted) {
       return 'bg-amber-400 text-gray-900 ring-2 ring-amber-400 animate-pulse';
     }
@@ -65,6 +73,9 @@ export function NoteCell({
   };
 
   const getRingStyle = (): React.CSSProperties => {
+    if (isAgentHighlighted) {
+      return { backgroundColor: '#7c3aed' };
+    }
     if (isHighlighted) {
       return {};
     }
@@ -75,7 +86,7 @@ export function NoteCell({
   };
 
   const getScaleNoteStyle = (): React.CSSProperties => {
-    if (isHighlighted) return {};
+    if (isAgentHighlighted || isHighlighted) return {};
 
     if (isInScale && !isRoot && !voicingLabel) {
       if (hasChordOverlay) {
@@ -94,7 +105,8 @@ export function NoteCell({
   };
 
   const displayText = displayMode === 'intervals' && degreeLabel ? degreeLabel : note;
-  const isDimmed = !isHighlighted && !isInScale && !isRoot && !voicingLabel;
+  const isDimmed = !isAgentHighlighted && !isHighlighted && !isInScale && !isRoot && !voicingLabel;
+  const isAgentDimmed = hasAgentHighlightLayer && !isAgentHighlighted && !isDimmed;
 
   const handleClick = (e: React.MouseEvent) => {
     if (onClick && isClickable) {
@@ -129,7 +141,7 @@ export function NoteCell({
           shadow-sm
           ${isClickable ? 'cursor-pointer hover:scale-[1.15] hover:shadow-md hover:z-20' : 'cursor-default'}
           ${getColorClasses()}
-          ${isDimmed ? 'opacity-40' : ''}
+          ${isDimmed ? 'opacity-40' : isAgentDimmed ? 'opacity-30' : ''}
         `}
         style={{
           ...getRingStyle(),
@@ -139,7 +151,7 @@ export function NoteCell({
             color: darkMode ? '#94a3b8' : '#9ca3af'
           } : {})
         }}
-        title={`${note} - Fret ${fret}${degreeLabel ? ` (${degreeLabel})` : ''}${isHighlighted ? ' (highlighted from tab beat)' : ''}${isClickable ? ' (click for chord)' : ''}`}
+        title={`${note} - Fret ${fret}${degreeLabel ? ` (${degreeLabel})` : ''}${isAgentHighlighted ? ' (agent highlight)' : ''}${isHighlighted ? ' (highlighted from tab beat)' : ''}${isClickable ? ' (click for chord)' : ''}`}
       >
         {displayText}
       </button>

--- a/frontend/src/components/Fretboard/StringRow.tsx
+++ b/frontend/src/components/Fretboard/StringRow.tsx
@@ -1,4 +1,4 @@
-import type { NotePosition, ScaleNotePosition, ChordVoicing } from '../../types';
+import type { NotePosition, ScaleNotePosition, ChordVoicing, HighlightedNote } from '../../types';
 import { NoteCell } from './NoteCell';
 
 interface ChordPositionInfo {
@@ -27,6 +27,7 @@ interface StringRowProps {
   displayMode?: 'notes' | 'intervals';
   onNoteClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   clickableNotes?: Set<string>;
+  highlightedNotes?: HighlightedNote[];
   darkMode?: boolean;
   hasChordOverlay?: boolean;
 }
@@ -41,6 +42,7 @@ export function StringRow({
   displayMode = 'notes',
   onNoteClick,
   clickableNotes,
+  highlightedNotes = [],
   darkMode = false,
   hasChordOverlay = false,
 }: StringRowProps) {
@@ -66,6 +68,10 @@ export function StringRow({
         });
     });
 
+  const highlightedMap = new Set(
+    highlightedNotes.map((note) => `${note.string}:${note.fret}`),
+  );
+
   return (
     <div className="flex items-stretch">
       <div className="w-10 flex-shrink-0 flex items-center justify-center text-xs font-bold" style={{ color: 'var(--text-muted)' }}>
@@ -87,6 +93,7 @@ export function StringRow({
           const scalePos = scaleMap.get(notePos.fret);
           const chordPos = chordMap.get(notePos.fret);
           const isClickable = clickableNotes?.has(notePos.note) && !!scalePos;
+          const isHighlighted = highlightedMap.has(`${stringNumber}:${notePos.fret}`);
 
           return (
             <NoteCell
@@ -104,6 +111,7 @@ export function StringRow({
               hasChordOverlay={hasChordOverlay}
               onClick={onNoteClick}
               isClickable={isClickable}
+              isHighlighted={isHighlighted}
               darkMode={darkMode}
             />
           );

--- a/frontend/src/components/Fretboard/StringRow.tsx
+++ b/frontend/src/components/Fretboard/StringRow.tsx
@@ -1,4 +1,5 @@
 import type { NotePosition, ScaleNotePosition, ChordVoicing, HighlightedNote } from '../../types';
+import type { FretboardHighlightPosition } from '../../types/chat';
 import { NoteCell } from './NoteCell';
 
 interface ChordPositionInfo {
@@ -28,6 +29,8 @@ interface StringRowProps {
   onNoteClick?: (e: React.MouseEvent, note: string, string: number, fret: number) => void;
   clickableNotes?: Set<string>;
   highlightedNotes?: HighlightedNote[];
+  agentHighlightPositions?: FretboardHighlightPosition[];
+  hasAgentHighlightLayer?: boolean;
   darkMode?: boolean;
   hasChordOverlay?: boolean;
 }
@@ -43,6 +46,8 @@ export function StringRow({
   onNoteClick,
   clickableNotes,
   highlightedNotes = [],
+  agentHighlightPositions = [],
+  hasAgentHighlightLayer = false,
   darkMode = false,
   hasChordOverlay = false,
 }: StringRowProps) {
@@ -72,6 +77,12 @@ export function StringRow({
     highlightedNotes.map((note) => `${note.string}:${note.fret}`),
   );
 
+  const agentHighlightMap = new Set(
+    agentHighlightPositions
+      .filter((pos) => pos.string === stringNumber)
+      .map((pos) => pos.fret),
+  );
+
   return (
     <div className="flex items-stretch">
       <div className="w-10 flex-shrink-0 flex items-center justify-center text-xs font-bold" style={{ color: 'var(--text-muted)' }}>
@@ -94,6 +105,7 @@ export function StringRow({
           const chordPos = chordMap.get(notePos.fret);
           const isClickable = clickableNotes?.has(notePos.note) && !!scalePos;
           const isHighlighted = highlightedMap.has(`${stringNumber}:${notePos.fret}`);
+          const isAgentHighlighted = agentHighlightMap.has(notePos.fret);
 
           return (
             <NoteCell
@@ -112,6 +124,8 @@ export function StringRow({
               onClick={onNoteClick}
               isClickable={isClickable}
               isHighlighted={isHighlighted}
+              isAgentHighlighted={isAgentHighlighted}
+              hasAgentHighlightLayer={hasAgentHighlightLayer}
               darkMode={darkMode}
             />
           );

--- a/frontend/src/components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/components/ScaleSelector/ScaleSelector.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { ScaleCategory } from '../../types';
 import { apiClient } from '../../api/client';
 
-const ROOT_NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const ROOT_NOTES = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
 
 interface ScaleSelectorProps {
   selectedRoot: string;

--- a/frontend/src/components/ScaleSelector/ScaleSelector.tsx
+++ b/frontend/src/components/ScaleSelector/ScaleSelector.tsx
@@ -11,7 +11,7 @@ interface ScaleSelectorProps {
   darkMode?: boolean;
 }
 
-export function ScaleSelector({ selectedRoot, selectedMode, onSelect, darkMode = false }: ScaleSelectorProps) {
+export function ScaleSelector({ selectedRoot, selectedMode, onSelect, darkMode: _darkMode = false }: ScaleSelectorProps) {
   const [scaleCategories, setScaleCategories] = useState<ScaleCategory[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -30,19 +30,23 @@ export function ScaleSelector({ selectedRoot, selectedMode, onSelect, darkMode =
     onSelect(selectedRoot, newMode);
   };
 
+  const scaleLabel = `${selectedRoot} ${selectedMode
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())}`;
+
   if (loading) {
     return <div style={{ color: 'var(--text-muted)' }}>Loading scales...</div>;
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 md:gap-6">
+    <div className="flex flex-wrap items-end gap-2 md:gap-3">
       {/* Root Note Selector */}
       <div className="flex flex-col gap-1">
         <label className="text-[10px] md:text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>Root</label>
         <select
           value={selectedRoot}
           onChange={(e) => handleRootChange(e.target.value)}
-          className="px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer touch-target"
+          className="min-w-[84px] px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer touch-target"
           style={{
             backgroundColor: 'var(--bg-input)',
             borderColor: 'var(--border-primary)',
@@ -59,12 +63,12 @@ export function ScaleSelector({ selectedRoot, selectedMode, onSelect, darkMode =
       </div>
 
       {/* Mode Selector */}
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-1 min-w-[170px]">
         <label className="text-[10px] md:text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>Scale</label>
         <select
           value={selectedMode}
           onChange={(e) => handleModeChange(e.target.value)}
-          className="px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer min-w-[140px] md:min-w-[180px] touch-target"
+          className="w-full px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer min-w-[170px] md:w-[220px] md:min-w-[220px] touch-target"
           style={{
             backgroundColor: 'var(--bg-input)',
             borderColor: 'var(--border-primary)',
@@ -84,20 +88,19 @@ export function ScaleSelector({ selectedRoot, selectedMode, onSelect, darkMode =
         </select>
       </div>
 
-      {/* Current Selection Display - hide on mobile */}
       <div className="hidden lg:block h-10 w-px" style={{ backgroundColor: 'var(--border-primary)' }}></div>
-      <div 
+      <div
         className="hidden lg:block px-4 py-2 rounded-lg border"
         style={{
-          backgroundColor: darkMode ? 'var(--accent-900)' : 'var(--accent-50)',
-          borderColor: darkMode ? 'var(--accent-700)' : 'var(--accent-200)'
+          backgroundColor: _darkMode ? 'var(--accent-900)' : 'var(--accent-50)',
+          borderColor: _darkMode ? 'var(--accent-700)' : 'var(--accent-200)'
         }}
       >
-        <span 
+        <span
           className="text-lg font-bold"
-          style={{ color: darkMode ? 'var(--accent-300)' : 'var(--accent-700)' }}
+          style={{ color: _darkMode ? 'var(--accent-300)' : 'var(--accent-700)' }}
         >
-          {selectedRoot} {selectedMode.replace(/_/g, ' ')}
+          {scaleLabel}
         </span>
       </div>
     </div>

--- a/frontend/src/components/SongControls/SongControls.tsx
+++ b/frontend/src/components/SongControls/SongControls.tsx
@@ -1,4 +1,5 @@
 import { useAppStore } from '../../stores/useAppStore';
+import { formatTuning } from '../../utils/tuning';
 
 export function SongControls() {
   const selectedSong = useAppStore((s) => s.selectedSong);
@@ -17,6 +18,10 @@ export function SongControls() {
 
   const tracks = songTracks?.tracks ?? selectedSong.tracks;
   const chordsAvailable = selectedSong.has_chords;
+  const selectedTrack =
+    tracks.find((track) => track.index === selectedTrackIndex) ??
+    tracks[0];
+  const selectedTrackTuning = formatTuning(selectedTrack?.tuning);
 
   const handleViewModeChange = async (mode: 'tab' | 'chords') => {
     setSongViewMode(mode);
@@ -38,6 +43,7 @@ export function SongControls() {
         </div>
         <div className="text-[11px] md:text-xs" style={{ color: 'var(--text-muted)' }}>
           Song ID: {selectedSong.song_id}
+          {selectedTrackTuning ? ` • Tuning: ${selectedTrackTuning}` : ''}
         </div>
       </div>
 
@@ -57,6 +63,7 @@ export function SongControls() {
               {track.name || track.instrument}
               {track.is_vocal ? ' (vocal)' : ''}
               {track.is_empty ? ' (empty)' : ''}
+              {track.tuning?.length ? ` • ${formatTuning(track.tuning)}` : ''}
             </option>
           ))}
         </select>
@@ -116,4 +123,3 @@ export function SongControls() {
     </div>
   );
 }
-

--- a/frontend/src/components/SongControls/SongControls.tsx
+++ b/frontend/src/components/SongControls/SongControls.tsx
@@ -46,22 +46,76 @@ export function SongControls() {
   };
 
   return (
-    <div className="flex flex-col md:flex-row md:items-center justify-between gap-3 md:gap-4 w-full">
-      <div className="min-w-0">
-        <div className="text-xs md:text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+    <div className="flex flex-col gap-3 md:gap-4 w-full">
+      <div className="flex items-center gap-2 min-w-0 text-[11px] md:text-xs">
+        <button
+          type="button"
+          onClick={backToSearch}
+          className="truncate transition-opacity hover:opacity-80"
+          style={{ color: 'var(--accent-600)' }}
+          title="Back to Search Results"
+        >
+          Songs / Search Results
+        </button>
+        <span style={{ color: 'var(--text-muted)' }}>/</span>
+        <span className="truncate" style={{ color: 'var(--text-muted)' }}>
           {selectedSong.artist} - {selectedSong.title}
-        </div>
-        <div className="text-[11px] md:text-xs" style={{ color: 'var(--text-muted)' }}>
-          Song ID: {selectedSong.song_id}
-          {tuningDisplay ? ` • Tuning: ${tuningDisplay}` : ''}
-        </div>
+        </span>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2 md:gap-3">
+      <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-3 md:gap-4">
+        <div className="min-w-0">
+          <div className="text-xs md:text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+            {selectedSong.artist} - {selectedSong.title}
+          </div>
+          <div className="text-[11px] md:text-xs" style={{ color: 'var(--text-muted)' }}>
+            Song ID: {selectedSong.song_id}
+            {tuningDisplay ? ` • Tuning: ${tuningDisplay}` : ''}
+          </div>
+          <div
+            className="mt-2 inline-flex rounded-lg p-0.5 border"
+            style={{
+              borderColor: 'var(--border-primary)',
+              backgroundColor: 'var(--bg-tertiary)',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => void handleViewModeChange('tab')}
+              className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
+                songViewMode === 'tab' ? 'shadow-sm border' : ''
+              }`}
+              style={{
+                borderColor: songViewMode === 'tab' ? 'var(--border-primary)' : 'transparent',
+                backgroundColor: songViewMode === 'tab' ? 'var(--card-bg)' : 'transparent',
+                color: songViewMode === 'tab' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+            >
+              Tab
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleViewModeChange('chords')}
+              disabled={!chordsAvailable}
+              className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
+                songViewMode === 'chords' ? 'shadow-sm border' : ''
+              } disabled:opacity-50 disabled:cursor-not-allowed`}
+              style={{
+                borderColor: songViewMode === 'chords' ? 'var(--border-primary)' : 'transparent',
+                backgroundColor: songViewMode === 'chords' ? 'var(--card-bg)' : 'transparent',
+                color: songViewMode === 'chords' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+              title={chordsAvailable ? 'Show ChordPro lyrics/chords' : 'No chords available'}
+            >
+              Chords
+            </button>
+          </div>
+        </div>
+
         <select
           value={selectedTrackIndex}
           onChange={(e) => void selectTrack(Number(e.target.value))}
-          className="px-3 py-2 rounded-lg text-xs md:text-sm border"
+          className="w-full lg:w-auto lg:min-w-[360px] px-3 py-2 rounded-lg text-xs md:text-sm border"
           style={{
             borderColor: 'var(--border-primary)',
             backgroundColor: 'var(--bg-secondary)',
@@ -77,58 +131,6 @@ export function SongControls() {
             </option>
           ))}
         </select>
-
-        <div
-          className="flex rounded-lg p-0.5 border"
-          style={{
-            borderColor: 'var(--border-primary)',
-            backgroundColor: 'var(--bg-tertiary)',
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => void handleViewModeChange('tab')}
-            className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
-              songViewMode === 'tab' ? 'shadow-sm border' : ''
-            }`}
-            style={{
-              borderColor: songViewMode === 'tab' ? 'var(--border-primary)' : 'transparent',
-              backgroundColor: songViewMode === 'tab' ? 'var(--card-bg)' : 'transparent',
-              color: songViewMode === 'tab' ? 'var(--accent-600)' : 'var(--text-tertiary)',
-            }}
-          >
-            Tab
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleViewModeChange('chords')}
-            disabled={!chordsAvailable}
-            className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
-              songViewMode === 'chords' ? 'shadow-sm border' : ''
-            } disabled:opacity-50 disabled:cursor-not-allowed`}
-            style={{
-              borderColor: songViewMode === 'chords' ? 'var(--border-primary)' : 'transparent',
-              backgroundColor: songViewMode === 'chords' ? 'var(--card-bg)' : 'transparent',
-              color: songViewMode === 'chords' ? 'var(--accent-600)' : 'var(--text-tertiary)',
-            }}
-            title={chordsAvailable ? 'Show ChordPro lyrics/chords' : 'No chords available'}
-          >
-            Chords
-          </button>
-        </div>
-
-        <button
-          type="button"
-          onClick={backToSearch}
-          className="px-3 py-2 rounded-lg text-xs md:text-sm font-medium border"
-          style={{
-            borderColor: 'var(--border-primary)',
-            backgroundColor: 'var(--card-bg)',
-            color: 'var(--text-secondary)',
-          }}
-        >
-          Back to Search
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/SongControls/SongControls.tsx
+++ b/frontend/src/components/SongControls/SongControls.tsx
@@ -8,6 +8,9 @@ export function SongControls() {
   const songViewMode = useAppStore((s) => s.songViewMode);
   const chordProData = useAppStore((s) => s.chordProData);
   const chordProLoading = useAppStore((s) => s.chordProLoading);
+  const selectedTuning = useAppStore((s) => s.selectedTuning);
+  const availableTunings = useAppStore((s) => s.availableTunings);
+  const customTuningNotes = useAppStore((s) => s.customTuningNotes);
 
   const selectTrack = useAppStore((s) => s.selectTrack);
   const setSongViewMode = useAppStore((s) => s.setSongViewMode);
@@ -21,7 +24,14 @@ export function SongControls() {
   const selectedTrack =
     tracks.find((track) => track.index === selectedTrackIndex) ??
     tracks[0];
-  const selectedTrackTuning = formatTuning(selectedTrack?.tuning);
+
+  // Show tuning name from matched tuning, or fall back to note letters
+  const matchedTuning = availableTunings.find((t) => t.id === selectedTuning);
+  const tuningDisplay = matchedTuning
+    ? `${matchedTuning.name} (${[...matchedTuning.notes].reverse().join(' ')})`
+    : customTuningNotes
+      ? `Custom (${[...customTuningNotes].reverse().join(' ')})`
+      : formatTuning(selectedTrack?.tuning);
 
   const handleViewModeChange = async (mode: 'tab' | 'chords') => {
     setSongViewMode(mode);
@@ -43,7 +53,7 @@ export function SongControls() {
         </div>
         <div className="text-[11px] md:text-xs" style={{ color: 'var(--text-muted)' }}>
           Song ID: {selectedSong.song_id}
-          {selectedTrackTuning ? ` • Tuning: ${selectedTrackTuning}` : ''}
+          {tuningDisplay ? ` • Tuning: ${tuningDisplay}` : ''}
         </div>
       </div>
 

--- a/frontend/src/components/SongControls/SongControls.tsx
+++ b/frontend/src/components/SongControls/SongControls.tsx
@@ -1,0 +1,119 @@
+import { useAppStore } from '../../stores/useAppStore';
+
+export function SongControls() {
+  const selectedSong = useAppStore((s) => s.selectedSong);
+  const songTracks = useAppStore((s) => s.songTracks);
+  const selectedTrackIndex = useAppStore((s) => s.selectedTrackIndex);
+  const songViewMode = useAppStore((s) => s.songViewMode);
+  const chordProData = useAppStore((s) => s.chordProData);
+  const chordProLoading = useAppStore((s) => s.chordProLoading);
+
+  const selectTrack = useAppStore((s) => s.selectTrack);
+  const setSongViewMode = useAppStore((s) => s.setSongViewMode);
+  const fetchChordPro = useAppStore((s) => s.fetchChordPro);
+  const backToSearch = useAppStore((s) => s.backToSearch);
+
+  if (!selectedSong) return null;
+
+  const tracks = songTracks?.tracks ?? selectedSong.tracks;
+  const chordsAvailable = selectedSong.has_chords;
+
+  const handleViewModeChange = async (mode: 'tab' | 'chords') => {
+    setSongViewMode(mode);
+    if (
+      mode === 'chords' &&
+      chordsAvailable &&
+      !chordProData &&
+      !chordProLoading
+    ) {
+      await fetchChordPro(selectedSong.song_id);
+    }
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row md:items-center justify-between gap-3 md:gap-4 w-full">
+      <div className="min-w-0">
+        <div className="text-xs md:text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
+          {selectedSong.artist} - {selectedSong.title}
+        </div>
+        <div className="text-[11px] md:text-xs" style={{ color: 'var(--text-muted)' }}>
+          Song ID: {selectedSong.song_id}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 md:gap-3">
+        <select
+          value={selectedTrackIndex}
+          onChange={(e) => void selectTrack(Number(e.target.value))}
+          className="px-3 py-2 rounded-lg text-xs md:text-sm border"
+          style={{
+            borderColor: 'var(--border-primary)',
+            backgroundColor: 'var(--bg-secondary)',
+            color: 'var(--text-primary)',
+          }}
+        >
+          {tracks.map((track) => (
+            <option key={track.index} value={track.index}>
+              {track.name || track.instrument}
+              {track.is_vocal ? ' (vocal)' : ''}
+              {track.is_empty ? ' (empty)' : ''}
+            </option>
+          ))}
+        </select>
+
+        <div
+          className="flex rounded-lg p-0.5 border"
+          style={{
+            borderColor: 'var(--border-primary)',
+            backgroundColor: 'var(--bg-tertiary)',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => void handleViewModeChange('tab')}
+            className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
+              songViewMode === 'tab' ? 'shadow-sm border' : ''
+            }`}
+            style={{
+              borderColor: songViewMode === 'tab' ? 'var(--border-primary)' : 'transparent',
+              backgroundColor: songViewMode === 'tab' ? 'var(--card-bg)' : 'transparent',
+              color: songViewMode === 'tab' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+            }}
+          >
+            Tab
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleViewModeChange('chords')}
+            disabled={!chordsAvailable}
+            className={`px-3 py-1.5 text-xs md:text-sm rounded-md font-medium ${
+              songViewMode === 'chords' ? 'shadow-sm border' : ''
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
+            style={{
+              borderColor: songViewMode === 'chords' ? 'var(--border-primary)' : 'transparent',
+              backgroundColor: songViewMode === 'chords' ? 'var(--card-bg)' : 'transparent',
+              color: songViewMode === 'chords' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+            }}
+            title={chordsAvailable ? 'Show ChordPro lyrics/chords' : 'No chords available'}
+          >
+            Chords
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={backToSearch}
+          className="px-3 py-2 rounded-lg text-xs md:text-sm font-medium border"
+          style={{
+            borderColor: 'var(--border-primary)',
+            backgroundColor: 'var(--card-bg)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Back to Search
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/SongControls/index.ts
+++ b/frontend/src/components/SongControls/index.ts
@@ -1,0 +1,2 @@
+export { SongControls } from './SongControls';
+

--- a/frontend/src/components/SongSearch/SongSearch.tsx
+++ b/frontend/src/components/SongSearch/SongSearch.tsx
@@ -92,7 +92,6 @@ export function SongSearch() {
       {/* Initial state */}
       {results.length === 0 && inputValue.trim().length < 2 && (
         <div className="text-center py-16">
-          <div className="text-4xl mb-3">🎸</div>
           <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
             Search for a song to view its tab
           </p>

--- a/frontend/src/components/SongSearch/SongSearch.tsx
+++ b/frontend/src/components/SongSearch/SongSearch.tsx
@@ -1,0 +1,161 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useAppStore, useSongSearch } from '../../stores/useAppStore';
+import type { SongSearchResult } from '../../types';
+
+export function SongSearch() {
+  const [inputValue, setInputValue] = useState('');
+  const { results, loading, error } = useSongSearch();
+  const searchSongs = useAppStore((s) => s.searchSongs);
+  const selectSong = useAppStore((s) => s.selectSong);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      setInputValue(query);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (query.trim().length < 2) return;
+      debounceRef.current = setTimeout(() => searchSongs(query.trim()), 300);
+    },
+    [searchSongs],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim().length >= 2) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      searchSongs(inputValue.trim());
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Search bar */}
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => handleSearch(e.target.value)}
+          placeholder="Search for a song or artist..."
+          className="flex-1 px-4 py-2.5 rounded-lg border text-sm outline-none transition-colors"
+          style={{
+            backgroundColor: 'var(--bg-secondary)',
+            borderColor: 'var(--border-primary)',
+            color: 'var(--text-primary)',
+          }}
+        />
+        <button
+          type="submit"
+          disabled={loading || inputValue.trim().length < 2}
+          className="px-4 py-2.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+          style={{
+            backgroundColor: 'var(--accent-500)',
+            color: 'white',
+          }}
+        >
+          {loading ? 'Searching...' : 'Search'}
+        </button>
+      </form>
+
+      {/* Error */}
+      {error && (
+        <div
+          className="px-4 py-3 rounded-lg text-sm"
+          style={{ backgroundColor: 'rgba(239,68,68,0.1)', color: '#ef4444' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Results */}
+      {results.length > 0 && (
+        <div className="space-y-1">
+          {results.map((song) => (
+            <SongResultRow key={song.song_id} song={song} onSelect={selectSong} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && results.length === 0 && inputValue.trim().length >= 2 && (
+        <div className="text-center py-12 text-sm" style={{ color: 'var(--text-muted)' }}>
+          No results found. Try a different search.
+        </div>
+      )}
+
+      {/* Initial state */}
+      {results.length === 0 && inputValue.trim().length < 2 && (
+        <div className="text-center py-16">
+          <div className="text-4xl mb-3">🎸</div>
+          <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            Search for a song to view its tab
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SongResultRow({
+  song,
+  onSelect,
+}: {
+  song: SongSearchResult;
+  onSelect: (song: SongSearchResult) => void;
+}) {
+  const instruments = song.tracks
+    .map((t) => t.instrument)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .slice(0, 4);
+
+  return (
+    <button
+      onClick={() => onSelect(song)}
+      className="w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors hover:scale-[1.005] active:scale-[0.995]"
+      style={{
+        backgroundColor: 'var(--card-bg)',
+        border: '1px solid var(--border-primary)',
+      }}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-sm truncate" style={{ color: 'var(--text-primary)' }}>
+          {song.title}
+        </div>
+        <div className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
+          {song.artist}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        {instruments.map((inst) => (
+          <span
+            key={inst}
+            className="px-2 py-0.5 rounded text-[10px]"
+            style={{
+              backgroundColor: 'var(--bg-hover)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {inst}
+          </span>
+        ))}
+        {song.has_chords && (
+          <span
+            className="px-2 py-0.5 rounded text-[10px] font-medium"
+            style={{
+              backgroundColor: 'rgba(16,185,129,0.15)',
+              color: 'var(--accent-500)',
+            }}
+          >
+            chords
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/SongSearch/SongSearch.tsx
+++ b/frontend/src/components/SongSearch/SongSearch.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppStore, useSongSearch } from '../../stores/useAppStore';
 import type { SongSearchResult } from '../../types';
+import { pickPrimaryTuning } from '../../utils/tuning';
 
 export function SongSearch() {
   const [inputValue, setInputValue] = useState('');
@@ -112,6 +113,7 @@ function SongResultRow({
     .map((t) => t.instrument)
     .filter((v, i, a) => a.indexOf(v) === i)
     .slice(0, 4);
+  const tuningText = pickPrimaryTuning(song.tracks.map((t) => t.tuning));
 
   return (
     <button
@@ -129,6 +131,11 @@ function SongResultRow({
         <div className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
           {song.artist}
         </div>
+        {tuningText && (
+          <div className="text-[11px] truncate mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+            Tuning: {tuningText}
+          </div>
+        )}
       </div>
 
       <div className="flex items-center gap-1.5 flex-shrink-0">

--- a/frontend/src/components/SongSearch/index.ts
+++ b/frontend/src/components/SongSearch/index.ts
@@ -1,0 +1,1 @@
+export { SongSearch } from './SongSearch';

--- a/frontend/src/components/TabViewer/MeasureGroup.tsx
+++ b/frontend/src/components/TabViewer/MeasureGroup.tsx
@@ -11,11 +11,13 @@ interface MeasureGroupProps {
   canStepPrev?: boolean;
   onStepPrev?: () => void;
   onBeatClick: (beat: TabBeat, beatId: string) => void;
+  tuningNotes?: string[];
 }
 
-const TAB_STRINGS = ['e|', 'B|', 'G|', 'D|', 'A|', 'E|'] as const;
+const DEFAULT_tabStrings = ['e|', 'B|', 'G|', 'D|', 'A|', 'E|'];
+const NUM_STRINGS = 6;
 const LINE_GAP_PX = 16;
-const STAFF_HEIGHT_PX = LINE_GAP_PX * (TAB_STRINGS.length - 1);
+const STAFF_HEIGHT_PX = LINE_GAP_PX * (NUM_STRINGS - 1);
 const MIN_MEASURE_WIDTH_PX = 180;
 const BEAT_SPACING_PX = 34;
 const TAB_FONT_FAMILY =
@@ -89,11 +91,11 @@ function formatNote(note?: TabNote): string {
   return text;
 }
 
-function mapNotesByString(notes: TabNote[]): Map<number, TabNote> {
+function mapNotesByString(notes: TabNote[], stringCount: number): Map<number, TabNote> {
   const byString = new Map<number, TabNote>();
   for (const note of notes) {
     if (typeof note.string !== 'number') continue;
-    if (note.string < 0 || note.string >= TAB_STRINGS.length) continue;
+    if (note.string < 0 || note.string >= stringCount) continue;
     if (!byString.has(note.string)) byString.set(note.string, note);
   }
   return byString;
@@ -109,7 +111,11 @@ export function MeasureGroup({
   canStepPrev = false,
   onStepPrev,
   onBeatClick,
+  tuningNotes,
 }: MeasureGroupProps) {
+  const tabStrings = tuningNotes
+    ? tuningNotes.map((n, i) => `${i === 0 ? n.toLowerCase() : n}|`)
+    : DEFAULT_tabStrings;
   const measureMinWidthPx = compact ? 150 : MIN_MEASURE_WIDTH_PX;
   const beatSpacingPx = compact ? 30 : BEAT_SPACING_PX;
   const noteFontSizePx = compact ? 12 : 13;
@@ -160,7 +166,7 @@ export function MeasureGroup({
             className="absolute top-6"
             style={{ left: leftSliceWidthPx + leftSliceGapPx, height: STAFF_HEIGHT_PX }}
           >
-            {TAB_STRINGS.map((label, stringIdx) => (
+            {tabStrings.map((label, stringIdx) => (
               <div
                 key={label}
                 className="absolute text-[11px] font-semibold font-mono leading-none -translate-y-1/2"
@@ -177,7 +183,7 @@ export function MeasureGroup({
 
           <div className="relative inline-flex" style={{ height: STAFF_HEIGHT_PX }}>
             <div className="absolute inset-0 pointer-events-none">
-              {TAB_STRINGS.map((_, stringIdx) => (
+              {tabStrings.map((_, stringIdx) => (
                 <div
                   key={stringIdx}
                   className="absolute left-0 right-0 h-px"
@@ -286,7 +292,7 @@ export function MeasureGroup({
                     beats.map((beat, beatIdx) => {
                       const beatId = `${measureIndex}:${beatIdx}`;
                       const xPercent = ((beatIdx + 0.5) / beatColumns) * 100;
-                      const notesByString = mapNotesByString(beat.notes ?? []);
+                      const notesByString = mapNotesByString(beat.notes ?? [], tabStrings.length);
                       const isSelected = beatId === selectedBeatId;
 
                       return (
@@ -306,7 +312,7 @@ export function MeasureGroup({
                             title="Click to highlight this beat on the fretboard"
                           />
 
-                          {TAB_STRINGS.map((_, stringIdx) => {
+                          {tabStrings.map((_, stringIdx) => {
                             const text = formatNote(notesByString.get(stringIdx));
                             if (!text) return null;
 

--- a/frontend/src/components/TabViewer/MeasureGroup.tsx
+++ b/frontend/src/components/TabViewer/MeasureGroup.tsx
@@ -1,0 +1,310 @@
+import type { CSSProperties } from 'react';
+import type { TabBeat, TabMeasure, TabNote } from '../../types';
+
+interface MeasureGroupProps {
+  measures: TabMeasure[];
+  startMeasureIndex: number;
+  selectedBeatId: string | null;
+  activeMeasureIndex?: number;
+  onBeatClick: (beat: TabBeat, beatId: string) => void;
+}
+
+const TAB_STRINGS = ['e|', 'B|', 'G|', 'D|', 'A|', 'E|'] as const;
+const LINE_GAP_PX = 16;
+const STAFF_HEIGHT_PX = LINE_GAP_PX * (TAB_STRINGS.length - 1);
+const MIN_MEASURE_WIDTH_PX = 180;
+const BEAT_SPACING_PX = 34;
+const TAB_FONT_FAMILY =
+  '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+const TECHNIQUE_SUFFIXES: Array<{ key: keyof TabNote; suffix: string }> = [
+  { key: 'slide', suffix: '/' },
+  { key: 'bend', suffix: 'b' },
+  { key: 'hp', suffix: 'h' },
+  { key: 'vibrato', suffix: '~' },
+  { key: 'harmonic', suffix: '*' },
+  { key: 'staccato', suffix: '.' },
+  { key: 'accentuated', suffix: '>' },
+];
+
+function getBeats(measure: TabMeasure): TabBeat[] {
+  const voices = measure.voices ?? [];
+  if (voices.length === 0) return [];
+  if (voices.length === 1) return voices[0]?.beats ?? [];
+
+  // Pick the voice with the most playable notes to avoid rendering empty/rest-only voices.
+  let bestBeats: TabBeat[] = voices[0]?.beats ?? [];
+  let bestScore = -1;
+
+  for (const voice of voices) {
+    const beats = voice?.beats ?? [];
+    const score = beats.reduce((acc, beat) => {
+      const noteCount = (beat.notes ?? []).filter((n) => !n.rest && !n.dead).length;
+      return acc + noteCount;
+    }, 0);
+    if (score > bestScore) {
+      bestScore = score;
+      bestBeats = beats;
+    }
+  }
+
+  return bestBeats;
+}
+
+function hasRenderableNotes(beats: TabBeat[]): boolean {
+  return beats.some((beat) => (beat.notes ?? []).some((note) => !note.rest));
+}
+
+function formatBeatAnnotation(beat: TabBeat): string {
+  const parts: string[] = [];
+
+  const chordName = beat.chord?.text?.trim();
+  if (chordName) parts.push(chordName);
+
+  if (beat.downStroke || beat.pickStroke === 'down') {
+    parts.push('v');
+  } else if (beat.upStroke || beat.pickStroke === 'up') {
+    parts.push('^');
+  }
+
+  if (beat.letRing) parts.push('let ring');
+  if (beat.palmMute) parts.push('P.M.');
+
+  return parts.join(' ').trim();
+}
+
+function formatNote(note?: TabNote): string {
+  if (!note || note.rest) return '';
+  if (note.dead) return 'x';
+
+  let text = String(note.fret ?? 0);
+  if (note.ghost) text = `(${text})`;
+
+  for (const { key, suffix } of TECHNIQUE_SUFFIXES) {
+    if (note[key]) text += suffix;
+  }
+  return text;
+}
+
+function mapNotesByString(notes: TabNote[]): Map<number, TabNote> {
+  const byString = new Map<number, TabNote>();
+  for (const note of notes) {
+    if (typeof note.string !== 'number') continue;
+    if (note.string < 0 || note.string >= TAB_STRINGS.length) continue;
+    if (!byString.has(note.string)) byString.set(note.string, note);
+  }
+  return byString;
+}
+
+export function MeasureGroup({
+  measures,
+  startMeasureIndex,
+  selectedBeatId,
+  activeMeasureIndex,
+  onBeatClick,
+}: MeasureGroupProps) {
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="rounded-xl border px-3 py-4 md:px-5 md:py-5"
+        style={{
+          borderColor: 'var(--border-primary)',
+          backgroundColor: 'var(--card-bg)',
+          boxShadow: 'var(--shadow-sm)',
+        }}
+      >
+        <div className="relative inline-block min-w-full pl-8 pr-2 pt-6 pb-7">
+          <div className="absolute left-0 top-6" style={{ height: STAFF_HEIGHT_PX }}>
+            {TAB_STRINGS.map((label, stringIdx) => (
+              <div
+                key={label}
+                className="absolute text-[11px] font-semibold font-mono leading-none -translate-y-1/2"
+                style={{
+                  top: stringIdx * LINE_GAP_PX,
+                  color: 'var(--text-muted)',
+                  fontFamily: TAB_FONT_FAMILY,
+                }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="relative inline-flex" style={{ height: STAFF_HEIGHT_PX }}>
+            <div className="absolute inset-0 pointer-events-none">
+              {TAB_STRINGS.map((_, stringIdx) => (
+                <div
+                  key={stringIdx}
+                  className="absolute left-0 right-0 h-px"
+                  style={{
+                    top: stringIdx * LINE_GAP_PX,
+                    backgroundColor: 'var(--border-secondary)',
+                  }}
+                />
+              ))}
+            </div>
+
+            {measures.map((measure, localMeasureIdx) => {
+              const measureIndex = startMeasureIndex + localMeasureIdx;
+              const beats = getBeats(measure);
+              const hasNotes = hasRenderableNotes(beats);
+              const beatColumns = Math.max(beats.length, 1);
+              const measureWidth = Math.max(MIN_MEASURE_WIDTH_PX, beatColumns * BEAT_SPACING_PX);
+              const beatHitWidth = Math.max(24, Math.min(52, measureWidth / beatColumns));
+              const rawAnnotations = beats.map(formatBeatAnnotation);
+              const compactAnnotations = rawAnnotations.map((annotation, idx) => {
+                if (!annotation) return '';
+                if (idx > 0 && annotation === rawAnnotations[idx - 1]) return '';
+                return annotation;
+              });
+              const hasAnyAnnotation = compactAnnotations.some(Boolean);
+              const measureHasSelectedBeat = beats.some(
+                (_, beatIdx) => `${measureIndex}:${beatIdx}` === selectedBeatId,
+              );
+              const isPlayheadMeasure = activeMeasureIndex === measureIndex;
+              const isHighlightedMeasure = measureHasSelectedBeat || isPlayheadMeasure;
+              const isLastInRow = localMeasureIdx === measures.length - 1;
+              const measureStyle: CSSProperties = {
+                width: measureWidth,
+                borderRight: isLastInRow
+                  ? '1px solid var(--border-secondary)'
+                  : '1px dashed var(--border-secondary)',
+              };
+
+              return (
+                <div
+                  key={measureIndex}
+                  data-measure-index={measureIndex}
+                  className="relative shrink-0"
+                  style={measureStyle}
+                >
+                  {isHighlightedMeasure && (
+                    <div
+                      className="absolute inset-y-0 left-0 right-0 pointer-events-none"
+                      style={{
+                        backgroundColor: isPlayheadMeasure
+                          ? 'rgba(16,185,129,0.08)'
+                          : 'rgba(16,185,129,0.05)',
+                        borderLeft: '1px solid rgba(16,185,129,0.3)',
+                        borderRight: '1px solid rgba(16,185,129,0.3)',
+                      }}
+                    />
+                  )}
+
+                  <div
+                    className="absolute -top-5 left-3 text-[11px] font-semibold font-mono"
+                    style={{
+                      color: isHighlightedMeasure ? 'var(--accent-500)' : 'var(--text-muted)',
+                      fontFamily: TAB_FONT_FAMILY,
+                    }}
+                  >
+                    M{measureIndex + 1}
+                  </div>
+
+                  {measure.marker?.text && (
+                    <div
+                      className="absolute -top-10 left-2 rounded-full border px-2 py-0.5 text-[10px] font-semibold"
+                      style={{
+                        borderColor: 'var(--accent-600)',
+                        color: 'var(--accent-600)',
+                        backgroundColor: 'rgba(16,185,129,0.1)',
+                      }}
+                    >
+                      {measure.marker.text}
+                    </div>
+                  )}
+
+                  {beats.length > 0 && hasAnyAnnotation && (
+                    <div
+                      className="absolute left-0 right-0 z-20 flex pointer-events-none"
+                      style={{ top: STAFF_HEIGHT_PX + 6 }}
+                    >
+                      {compactAnnotations.map((annotation, beatIdx) => (
+                        <div
+                          key={`annotation:${measureIndex}:${beatIdx}`}
+                          className="px-0.5 text-[10px] leading-none text-center truncate"
+                          style={{
+                            width: `${100 / beatColumns}%`,
+                            color: 'var(--text-secondary)',
+                          }}
+                          title={annotation || undefined}
+                        >
+                          {annotation || ' '}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {beats.length > 0 &&
+                    beats.map((beat, beatIdx) => {
+                      const beatId = `${measureIndex}:${beatIdx}`;
+                      const xPercent = ((beatIdx + 0.5) / beatColumns) * 100;
+                      const notesByString = mapNotesByString(beat.notes ?? []);
+                      const isSelected = beatId === selectedBeatId;
+
+                      return (
+                        <div key={beatId}>
+                          <button
+                            type="button"
+                            onClick={() => onBeatClick(beat, beatId)}
+                            className="absolute -top-5 -bottom-3 z-10 -translate-x-1/2 rounded-sm transition-colors"
+                            style={{
+                              left: `${xPercent}%`,
+                              width: beatHitWidth,
+                              backgroundColor: isSelected ? 'rgba(16,185,129,0.12)' : 'transparent',
+                              border: isSelected
+                                ? '1px solid rgba(16,185,129,0.35)'
+                                : '1px solid transparent',
+                            }}
+                            title="Click to highlight this beat on the fretboard"
+                          />
+
+                          {TAB_STRINGS.map((_, stringIdx) => {
+                            const text = formatNote(notesByString.get(stringIdx));
+                            if (!text) return null;
+
+                            return (
+                              <div
+                                key={`${beatId}:${stringIdx}`}
+                                className="absolute z-20 -translate-x-1/2 -translate-y-1/2 px-1 text-[13px] font-semibold font-mono leading-none pointer-events-none"
+                                style={{
+                                  left: `${xPercent}%`,
+                                  top: stringIdx * LINE_GAP_PX,
+                                  color: isSelected ? 'var(--accent-400)' : 'var(--text-primary)',
+                                  backgroundColor: 'var(--card-bg)',
+                                  fontFamily: TAB_FONT_FAMILY,
+                                }}
+                              >
+                                {text}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+
+                  {beats.length === 0 && (
+                    <div
+                      className="absolute inset-0 flex items-center justify-center text-xs italic"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      No beats
+                    </div>
+                  )}
+
+                  {beats.length > 0 && !hasNotes && (
+                    <div
+                      className="absolute inset-0 flex items-center justify-center text-sm italic pointer-events-none"
+                      style={{ color: 'var(--text-muted)' }}
+                    >
+                      Rest ({beats.length} beat{beats.length === 1 ? '' : 's'})
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TabViewer/MeasureGroup.tsx
+++ b/frontend/src/components/TabViewer/MeasureGroup.tsx
@@ -6,6 +6,10 @@ interface MeasureGroupProps {
   startMeasureIndex: number;
   selectedBeatId: string | null;
   activeMeasureIndex?: number;
+  compact?: boolean;
+  showLeftBackSlice?: boolean;
+  canStepPrev?: boolean;
+  onStepPrev?: () => void;
   onBeatClick: (beat: TabBeat, beatId: string) => void;
 }
 
@@ -100,20 +104,62 @@ export function MeasureGroup({
   startMeasureIndex,
   selectedBeatId,
   activeMeasureIndex,
+  compact = false,
+  showLeftBackSlice = false,
+  canStepPrev = false,
+  onStepPrev,
   onBeatClick,
 }: MeasureGroupProps) {
+  const measureMinWidthPx = compact ? 150 : MIN_MEASURE_WIDTH_PX;
+  const beatSpacingPx = compact ? 30 : BEAT_SPACING_PX;
+  const noteFontSizePx = compact ? 12 : 13;
+  const annotationFontSizePx = compact ? 9 : 10;
+  const leftSliceWidthPx = compact && showLeftBackSlice ? 24 : 0;
+  const leftSliceGapPx = compact && showLeftBackSlice ? 6 : 0;
+  const leftPaddingPx = 32 + leftSliceWidthPx + leftSliceGapPx;
+
   return (
     <div className="overflow-x-auto">
       <div
-        className="rounded-xl border px-3 py-4 md:px-5 md:py-5"
+        className={compact ? 'rounded-xl border px-2 py-3 md:px-3 md:py-4' : 'rounded-xl border px-3 py-4 md:px-5 md:py-5'}
         style={{
           borderColor: 'var(--border-primary)',
           backgroundColor: 'var(--card-bg)',
           boxShadow: 'var(--shadow-sm)',
         }}
       >
-        <div className="relative inline-block min-w-full pl-8 pr-2 pt-6 pb-7">
-          <div className="absolute left-0 top-6" style={{ height: STAFF_HEIGHT_PX }}>
+        <div
+          className="relative inline-block min-w-full pr-2 pt-6 pb-7"
+          style={{ paddingLeft: leftPaddingPx }}
+        >
+          {compact && showLeftBackSlice && (
+            <div
+              className="absolute left-0 rounded-md overflow-hidden border"
+              style={{
+                top: 6,
+                bottom: 7,
+                width: leftSliceWidthPx,
+                borderColor: 'var(--border-primary)',
+                backgroundColor: 'var(--bg-secondary)',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onStepPrev}
+                disabled={!canStepPrev}
+                className="h-full w-full text-[10px] font-semibold flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+                style={{ color: 'var(--text-secondary)' }}
+                title="Go to previous measure"
+              >
+                ◀
+              </button>
+            </div>
+          )}
+
+          <div
+            className="absolute top-6"
+            style={{ left: leftSliceWidthPx + leftSliceGapPx, height: STAFF_HEIGHT_PX }}
+          >
             {TAB_STRINGS.map((label, stringIdx) => (
               <div
                 key={label}
@@ -148,7 +194,7 @@ export function MeasureGroup({
               const beats = getBeats(measure);
               const hasNotes = hasRenderableNotes(beats);
               const beatColumns = Math.max(beats.length, 1);
-              const measureWidth = Math.max(MIN_MEASURE_WIDTH_PX, beatColumns * BEAT_SPACING_PX);
+              const measureWidth = Math.max(measureMinWidthPx, beatColumns * beatSpacingPx);
               const beatHitWidth = Math.max(24, Math.min(52, measureWidth / beatColumns));
               const rawAnnotations = beats.map(formatBeatAnnotation);
               const compactAnnotations = rawAnnotations.map((annotation, idx) => {
@@ -191,8 +237,9 @@ export function MeasureGroup({
                   )}
 
                   <div
-                    className="absolute -top-5 left-3 text-[11px] font-semibold font-mono"
+                    className="absolute left-3 text-[11px] font-semibold font-mono"
                     style={{
+                      top: compact ? -24 : -26,
                       color: isHighlightedMeasure ? 'var(--accent-500)' : 'var(--text-muted)',
                       fontFamily: TAB_FONT_FAMILY,
                     }}
@@ -221,10 +268,11 @@ export function MeasureGroup({
                       {compactAnnotations.map((annotation, beatIdx) => (
                         <div
                           key={`annotation:${measureIndex}:${beatIdx}`}
-                          className="px-0.5 text-[10px] leading-none text-center truncate"
+                          className="px-0.5 leading-none text-center truncate"
                           style={{
                             width: `${100 / beatColumns}%`,
                             color: 'var(--text-secondary)',
+                            fontSize: annotationFontSizePx,
                           }}
                           title={annotation || undefined}
                         >
@@ -265,13 +313,14 @@ export function MeasureGroup({
                             return (
                               <div
                                 key={`${beatId}:${stringIdx}`}
-                                className="absolute z-20 -translate-x-1/2 -translate-y-1/2 px-1 text-[13px] font-semibold font-mono leading-none pointer-events-none"
+                                className="absolute z-20 -translate-x-1/2 -translate-y-1/2 px-1 font-semibold font-mono leading-none pointer-events-none"
                                 style={{
                                   left: `${xPercent}%`,
                                   top: stringIdx * LINE_GAP_PX,
                                   color: isSelected ? 'var(--accent-400)' : 'var(--text-primary)',
                                   backgroundColor: 'var(--card-bg)',
                                   fontFamily: TAB_FONT_FAMILY,
+                                  fontSize: noteFontSizePx,
                                 }}
                               >
                                 {text}

--- a/frontend/src/components/TabViewer/TabViewer.tsx
+++ b/frontend/src/components/TabViewer/TabViewer.tsx
@@ -75,11 +75,27 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
   const [selectedBeatId, setSelectedBeatId] = useState<string | null>(null);
   const [playheadMeasureIndex, setPlayheadMeasureIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [focusFretboardMode, setFocusFretboardMode] = useState(true);
+  const focusWindowSize = Math.max(1, measuresPerRow);
 
-  const measureRows = useMemo(
-    () => chunkMeasures(tabData.measures ?? [], Math.max(1, measuresPerRow)),
-    [tabData.measures, measuresPerRow],
-  );
+  const measureRows = useMemo(() => {
+    const measures = tabData.measures ?? [];
+    if (!focusFretboardMode) {
+      return chunkMeasures(measures, Math.max(1, measuresPerRow)).map((rowMeasures, rowIndex) => ({
+        measures: rowMeasures,
+        startMeasureIndex: rowIndex * Math.max(1, measuresPerRow),
+      }));
+    }
+
+    const start = Math.max(0, playheadMeasureIndex);
+    const end = Math.min(measures.length, start + focusWindowSize);
+    return [
+      {
+        measures: measures.slice(start, end),
+        startMeasureIndex: start,
+      },
+    ];
+  }, [focusFretboardMode, measuresPerRow, playheadMeasureIndex, tabData.measures]);
   const bpm = tabData.automations?.tempo?.[0]?.bpm;
   const effectiveBpm = typeof bpm === 'number' && bpm > 0 ? bpm : 120;
   const measureCount = tabData.measures?.length ?? 0;
@@ -123,10 +139,13 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
     setPlayheadMeasureIndex(0);
     setSelectedBeatId(null);
     setIsPlaying(false);
+    setFocusFretboardMode(true);
   }, [tabData.measures]);
 
   useEffect(() => {
     if (!measureCount) return;
+    if (selectedBeatId) return;
+
     const currentMeasure = tabData.measures[playheadMeasureIndex];
     const beats = getBeatsFromMeasure(currentMeasure);
     const firstPlayableBeat = beats.find((beat) =>
@@ -135,7 +154,7 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
 
     if (firstPlayableBeat) {
       setHighlightedNotes(toHighlightedNotes(firstPlayableBeat));
-    } else if (!selectedBeatId) {
+    } else {
       setHighlightedNotes([]);
     }
   }, [playheadMeasureIndex, measureCount, selectedBeatId, setHighlightedNotes, tabData.measures]);
@@ -251,15 +270,28 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
               ▶
             </button>
           </div>
+          <button
+            type="button"
+            onClick={() => setFocusFretboardMode((current) => !current)}
+            className="h-8 px-3 rounded-full text-xs font-semibold border"
+            style={{
+              borderColor: focusFretboardMode ? 'var(--accent-600)' : 'var(--border-primary)',
+              color: focusFretboardMode ? 'var(--accent-500)' : 'var(--text-secondary)',
+              backgroundColor: focusFretboardMode ? 'rgba(16,185,129,0.1)' : 'var(--card-bg)',
+            }}
+            title="Toggle compact measure strip and focus on fretboard"
+          >
+            {focusFretboardMode ? 'Fret Focus On' : 'Fret Focus Off'}
+          </button>
           <div className="text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>
             M{Math.min(playheadMeasureIndex + 1, Math.max(1, measureCount))}
           </div>
         </div>
       </div>
 
-      <div className="space-y-6">
+      <div className={focusFretboardMode ? 'space-y-3' : 'space-y-6'}>
         {measureRows.map((row, rowIndex) => {
-          const rowMarker = row.find((m) => m.marker?.text)?.marker?.text;
+          const rowMarker = row.measures.find((m) => m.marker?.text)?.marker?.text;
           return (
             <div key={rowIndex} className="space-y-2">
               {rowMarker && (
@@ -277,10 +309,14 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
                 </div>
               )}
               <MeasureGroup
-                measures={row}
-                startMeasureIndex={rowIndex * Math.max(1, measuresPerRow)}
+                measures={row.measures}
+                startMeasureIndex={row.startMeasureIndex}
                 selectedBeatId={selectedBeatId}
                 activeMeasureIndex={playheadMeasureIndex}
+                compact={focusFretboardMode}
+                showLeftBackSlice={focusFretboardMode}
+                canStepPrev={playheadMeasureIndex > 0}
+                onStepPrev={stepToPrevMeasure}
                 onBeatClick={handleBeatClick}
               />
             </div>

--- a/frontend/src/components/TabViewer/TabViewer.tsx
+++ b/frontend/src/components/TabViewer/TabViewer.tsx
@@ -73,8 +73,11 @@ function getBeatsPerMeasure(measure?: TabMeasure): number {
 
 export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewerProps) {
   const setHighlightedNotes = useAppStore((s) => s.setHighlightedNotes);
-  const [selectedBeatId, setSelectedBeatId] = useState<string | null>(null);
-  const [playheadMeasureIndex, setPlayheadMeasureIndex] = useState(0);
+  const selectedBeatId = useAppStore((s) => s.selectedBeatId);
+  const playheadMeasureIndex = useAppStore((s) => s.playheadMeasureIndex);
+  const setSelectedBeatId = useAppStore((s) => s.setSelectedBeatId);
+  const setPlayheadMeasureIndex = useAppStore((s) => s.setPlayheadMeasureIndex);
+  const focusMeasureBeat = useAppStore((s) => s.focusMeasureBeat);
   const [isPlaying, setIsPlaying] = useState(false);
   const [focusFretboardMode, setFocusFretboardMode] = useState(true);
   const focusWindowSize = Math.max(1, measuresPerRow);
@@ -121,14 +124,15 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
   );
 
   const handleBeatClick = useCallback(
-    (beat: TabBeat, beatId: string) => {
+    (_beat: TabBeat, beatId: string) => {
       setIsPlaying(false);
-      setSelectedBeatId(beatId);
-      setHighlightedNotes(toHighlightedNotes(beat));
-      const measureIdx = Number(beatId.split(':')[0]);
-      if (!Number.isNaN(measureIdx)) setPlayheadMeasureIndex(measureIdx);
+      const [measurePart, beatPart] = beatId.split(':');
+      const measureIdx = Number(measurePart);
+      const beatIdx = Number(beatPart);
+      if (Number.isNaN(measureIdx)) return;
+      focusMeasureBeat(measureIdx, Number.isNaN(beatIdx) ? undefined : beatIdx);
     },
-    [setHighlightedNotes],
+    [focusMeasureBeat],
   );
 
   const moveBeatSelection = useCallback(
@@ -152,12 +156,9 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
 
       if (nextIndex < 0 || nextIndex >= beatSequence.length) return;
       const next = beatSequence[nextIndex];
-      const beatId = `${next.measureIndex}:${next.beatIndex}`;
-      setSelectedBeatId(beatId);
-      setPlayheadMeasureIndex(next.measureIndex);
-      setHighlightedNotes(toHighlightedNotes(next.beat));
+      focusMeasureBeat(next.measureIndex, next.beatIndex);
     },
-    [beatSequence, playheadMeasureIndex, selectedBeatSequenceIndex, setHighlightedNotes],
+    [beatSequence, focusMeasureBeat, playheadMeasureIndex, selectedBeatSequenceIndex],
   );
 
   const moveMeasureSelection = useCallback(
@@ -182,33 +183,31 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
       if (targetMeasureIndex === sourceMeasureIndex) return;
 
       const targetBeats = getBeatsFromMeasure(tabData.measures[targetMeasureIndex]);
-      setPlayheadMeasureIndex(targetMeasureIndex);
 
       if (targetBeats.length === 0) {
+        setPlayheadMeasureIndex(targetMeasureIndex);
         setSelectedBeatId(null);
         setHighlightedNotes([]);
         return;
       }
 
       const targetBeatIndex = Math.min(sourceBeatIndex, targetBeats.length - 1);
-      const targetBeat = targetBeats[targetBeatIndex];
-      setSelectedBeatId(`${targetMeasureIndex}:${targetBeatIndex}`);
-      setHighlightedNotes(toHighlightedNotes(targetBeat));
+      focusMeasureBeat(targetMeasureIndex, targetBeatIndex);
     },
-    [measureCount, playheadMeasureIndex, selectedBeatId, setHighlightedNotes, tabData.measures],
+    [focusMeasureBeat, measureCount, playheadMeasureIndex, selectedBeatId, setHighlightedNotes, setPlayheadMeasureIndex, setSelectedBeatId, tabData.measures],
   );
 
   const stepToPrevMeasure = useCallback(() => {
     setIsPlaying(false);
     setSelectedBeatId(null);
-    setPlayheadMeasureIndex((idx) => Math.max(0, idx - 1));
-  }, []);
+    setPlayheadMeasureIndex(Math.max(0, playheadMeasureIndex - 1));
+  }, [playheadMeasureIndex, setPlayheadMeasureIndex, setSelectedBeatId]);
 
   const stepToNextMeasure = useCallback(() => {
     setIsPlaying(false);
     setSelectedBeatId(null);
-    setPlayheadMeasureIndex((idx) => Math.min(Math.max(0, measureCount - 1), idx + 1));
-  }, [measureCount]);
+    setPlayheadMeasureIndex(Math.min(Math.max(0, measureCount - 1), playheadMeasureIndex + 1));
+  }, [measureCount, playheadMeasureIndex, setPlayheadMeasureIndex, setSelectedBeatId]);
 
   const togglePlayback = useCallback(() => {
     if (measureCount === 0) return;
@@ -227,7 +226,7 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
     setSelectedBeatId(null);
     setIsPlaying(false);
     setFocusFretboardMode(true);
-  }, [tabData.measures]);
+  }, [setPlayheadMeasureIndex, setSelectedBeatId, tabData.measures]);
 
   useEffect(() => {
     if (!measureCount) return;
@@ -256,12 +255,12 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
     const beatsInMeasure = getBeatsPerMeasure(tabData.measures[playheadMeasureIndex]);
     const measureMs = Math.max(1, beatsInMeasure) * (60 / effectiveBpm) * 1000;
     const timer = window.setTimeout(() => {
-      setPlayheadMeasureIndex((idx) => Math.min(measureCount - 1, idx + 1));
+      setPlayheadMeasureIndex(Math.min(measureCount - 1, playheadMeasureIndex + 1));
       setSelectedBeatId(null);
     }, measureMs);
 
     return () => window.clearTimeout(timer);
-  }, [effectiveBpm, isPlaying, measureCount, playheadMeasureIndex, tabData.measures]);
+  }, [effectiveBpm, isPlaying, measureCount, playheadMeasureIndex, setPlayheadMeasureIndex, setSelectedBeatId, tabData.measures]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/components/TabViewer/TabViewer.tsx
+++ b/frontend/src/components/TabViewer/TabViewer.tsx
@@ -1,0 +1,292 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAppStore } from '../../stores/useAppStore';
+import type { HighlightedNote, TabBeat, TabData, TabMeasure } from '../../types';
+import { MeasureGroup } from './MeasureGroup';
+
+interface TabViewerProps {
+  tabData: TabData;
+  measuresPerRow?: number;
+}
+
+function chunkMeasures(tabMeasures: TabData['measures'], size: number): TabData['measures'][] {
+  const groups: TabData['measures'][] = [];
+  for (let i = 0; i < tabMeasures.length; i += size) {
+    groups.push(tabMeasures.slice(i, i + size));
+  }
+  return groups;
+}
+
+function toHighlightedNotes(beat: TabBeat): HighlightedNote[] {
+  const seen = new Set<string>();
+  const highlights: HighlightedNote[] = [];
+
+  for (const note of beat.notes ?? []) {
+    if (note.rest || note.dead) continue;
+    if (typeof note.string !== 'number' || typeof note.fret !== 'number') continue;
+
+    // Songsterr strings are 0-5 (high e -> low E), fretboard uses 1-6.
+    const mappedString = note.string + 1;
+    if (mappedString < 1 || mappedString > 6) continue;
+
+    const key = `${mappedString}:${note.fret}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    highlights.push({
+      string: mappedString,
+      fret: note.fret,
+    });
+  }
+
+  return highlights;
+}
+
+function getBeatsFromMeasure(measure: TabMeasure): TabBeat[] {
+  const voices = measure.voices ?? [];
+  if (voices.length === 0) return [];
+  if (voices.length === 1) return voices[0]?.beats ?? [];
+
+  let bestBeats: TabBeat[] = voices[0]?.beats ?? [];
+  let bestScore = -1;
+
+  for (const voice of voices) {
+    const beats = voice?.beats ?? [];
+    const score = beats.reduce((acc, beat) => {
+      const noteCount = (beat.notes ?? []).filter((n) => !n.rest && !n.dead).length;
+      return acc + noteCount;
+    }, 0);
+    if (score > bestScore) {
+      bestScore = score;
+      bestBeats = beats;
+    }
+  }
+  return bestBeats;
+}
+
+function getBeatsPerMeasure(measure?: TabMeasure): number {
+  if (!measure) return 4;
+  const numerator = measure.header?.timeSignature?.numerator;
+  if (typeof numerator === 'number' && numerator > 0) return numerator;
+  return 4;
+}
+
+export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
+  const setHighlightedNotes = useAppStore((s) => s.setHighlightedNotes);
+  const [selectedBeatId, setSelectedBeatId] = useState<string | null>(null);
+  const [playheadMeasureIndex, setPlayheadMeasureIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const measureRows = useMemo(
+    () => chunkMeasures(tabData.measures ?? [], Math.max(1, measuresPerRow)),
+    [tabData.measures, measuresPerRow],
+  );
+  const bpm = tabData.automations?.tempo?.[0]?.bpm;
+  const effectiveBpm = typeof bpm === 'number' && bpm > 0 ? bpm : 120;
+  const measureCount = tabData.measures?.length ?? 0;
+
+  const handleBeatClick = useCallback(
+    (beat: TabBeat, beatId: string) => {
+      setIsPlaying(false);
+      setSelectedBeatId(beatId);
+      setHighlightedNotes(toHighlightedNotes(beat));
+      const measureIdx = Number(beatId.split(':')[0]);
+      if (!Number.isNaN(measureIdx)) setPlayheadMeasureIndex(measureIdx);
+    },
+    [setHighlightedNotes],
+  );
+
+  const stepToPrevMeasure = useCallback(() => {
+    setIsPlaying(false);
+    setSelectedBeatId(null);
+    setPlayheadMeasureIndex((idx) => Math.max(0, idx - 1));
+  }, []);
+
+  const stepToNextMeasure = useCallback(() => {
+    setIsPlaying(false);
+    setSelectedBeatId(null);
+    setPlayheadMeasureIndex((idx) => Math.min(Math.max(0, measureCount - 1), idx + 1));
+  }, [measureCount]);
+
+  const togglePlayback = useCallback(() => {
+    if (measureCount === 0) return;
+    setSelectedBeatId(null);
+    setIsPlaying((current) => {
+      if (current) return false;
+      if (playheadMeasureIndex >= measureCount - 1) {
+        setPlayheadMeasureIndex(0);
+      }
+      return true;
+    });
+  }, [measureCount, playheadMeasureIndex]);
+
+  useEffect(() => {
+    setPlayheadMeasureIndex(0);
+    setSelectedBeatId(null);
+    setIsPlaying(false);
+  }, [tabData.measures]);
+
+  useEffect(() => {
+    if (!measureCount) return;
+    const currentMeasure = tabData.measures[playheadMeasureIndex];
+    const beats = getBeatsFromMeasure(currentMeasure);
+    const firstPlayableBeat = beats.find((beat) =>
+      (beat.notes ?? []).some((note) => !note.rest && !note.dead),
+    );
+
+    if (firstPlayableBeat) {
+      setHighlightedNotes(toHighlightedNotes(firstPlayableBeat));
+    } else if (!selectedBeatId) {
+      setHighlightedNotes([]);
+    }
+  }, [playheadMeasureIndex, measureCount, selectedBeatId, setHighlightedNotes, tabData.measures]);
+
+  useEffect(() => {
+    if (!isPlaying || measureCount === 0) return;
+    if (playheadMeasureIndex >= measureCount - 1) {
+      setIsPlaying(false);
+      return;
+    }
+
+    const beatsInMeasure = getBeatsPerMeasure(tabData.measures[playheadMeasureIndex]);
+    const measureMs = Math.max(1, beatsInMeasure) * (60 / effectiveBpm) * 1000;
+    const timer = window.setTimeout(() => {
+      setPlayheadMeasureIndex((idx) => Math.min(measureCount - 1, idx + 1));
+      setSelectedBeatId(null);
+    }, measureMs);
+
+    return () => window.clearTimeout(timer);
+  }, [effectiveBpm, isPlaying, measureCount, playheadMeasureIndex, tabData.measures]);
+
+  useEffect(() => {
+    if (!measureCount) return;
+    const measureEl = document.querySelector(`[data-measure-index="${playheadMeasureIndex}"]`);
+    if (measureEl instanceof HTMLElement) {
+      measureEl.scrollIntoView({
+        behavior: isPlaying ? 'smooth' : 'auto',
+        block: 'nearest',
+        inline: 'center',
+      });
+    }
+  }, [isPlaying, measureCount, playheadMeasureIndex]);
+
+  useEffect(() => {
+    return () => {
+      setHighlightedNotes([]);
+    };
+  }, [setHighlightedNotes]);
+
+  if (!tabData.measures?.length) {
+    return (
+      <div
+        className="rounded-xl border p-4 text-sm"
+        style={{
+          borderColor: 'var(--border-primary)',
+          backgroundColor: 'var(--card-bg)',
+          color: 'var(--text-muted)',
+        }}
+      >
+        No tab measures found for this track.
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-1">
+        <div>
+          <h3 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {tabData.name || 'Tab Viewer'}
+          </h3>
+          <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            Click any beat to highlight those notes on the fretboard.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="text-xs md:text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
+            {bpm ? `BPM ${bpm}` : 'BPM N/A'} • {tabData.measures.length} measures
+          </div>
+          <div
+            className="flex items-center gap-1 rounded-full border px-2 py-1"
+            style={{
+              borderColor: 'var(--border-primary)',
+              backgroundColor: 'var(--bg-secondary)',
+            }}
+          >
+            <button
+              type="button"
+              onClick={stepToPrevMeasure}
+              disabled={playheadMeasureIndex <= 0}
+              className="h-7 w-7 rounded-full text-xs font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: 'var(--card-bg)',
+                color: 'var(--text-secondary)',
+              }}
+              title="Previous measure"
+            >
+              ◀
+            </button>
+            <button
+              type="button"
+              onClick={togglePlayback}
+              className="h-8 min-w-16 px-2 rounded-full text-xs font-semibold"
+              style={{
+                backgroundColor: isPlaying ? 'var(--accent-600)' : 'var(--accent-500)',
+                color: 'white',
+              }}
+              title={isPlaying ? 'Pause playback' : 'Play from current measure'}
+            >
+              {isPlaying ? 'Pause' : 'Play'}
+            </button>
+            <button
+              type="button"
+              onClick={stepToNextMeasure}
+              disabled={playheadMeasureIndex >= Math.max(0, measureCount - 1)}
+              className="h-7 w-7 rounded-full text-xs font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{
+                backgroundColor: 'var(--card-bg)',
+                color: 'var(--text-secondary)',
+              }}
+              title="Next measure"
+            >
+              ▶
+            </button>
+          </div>
+          <div className="text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>
+            M{Math.min(playheadMeasureIndex + 1, Math.max(1, measureCount))}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {measureRows.map((row, rowIndex) => {
+          const rowMarker = row.find((m) => m.marker?.text)?.marker?.text;
+          return (
+            <div key={rowIndex} className="space-y-2">
+              {rowMarker && (
+                <div>
+                  <span
+                    className="inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold border"
+                    style={{
+                      borderColor: 'var(--accent-600)',
+                      color: 'var(--accent-600)',
+                      backgroundColor: 'rgba(16,185,129,0.1)',
+                    }}
+                  >
+                    {rowMarker}
+                  </span>
+                </div>
+              )}
+              <MeasureGroup
+                measures={row}
+                startMeasureIndex={rowIndex * Math.max(1, measuresPerRow)}
+                selectedBeatId={selectedBeatId}
+                activeMeasureIndex={playheadMeasureIndex}
+                onBeatClick={handleBeatClick}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/TabViewer/TabViewer.tsx
+++ b/frontend/src/components/TabViewer/TabViewer.tsx
@@ -403,7 +403,7 @@ export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewe
             }}
             title="Toggle compact measure strip and focus on fretboard"
           >
-            {focusFretboardMode ? 'Fret Focus On' : 'Fret Focus Off'}
+            Fret Focus
           </button>
           <div className="text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>
             M{Math.min(playheadMeasureIndex + 1, Math.max(1, measureCount))}

--- a/frontend/src/components/TabViewer/TabViewer.tsx
+++ b/frontend/src/components/TabViewer/TabViewer.tsx
@@ -6,6 +6,7 @@ import { MeasureGroup } from './MeasureGroup';
 interface TabViewerProps {
   tabData: TabData;
   measuresPerRow?: number;
+  tuningNotes?: string[];
 }
 
 function chunkMeasures(tabMeasures: TabData['measures'], size: number): TabData['measures'][] {
@@ -70,7 +71,7 @@ function getBeatsPerMeasure(measure?: TabMeasure): number {
   return 4;
 }
 
-export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
+export function TabViewer({ tabData, measuresPerRow = 4, tuningNotes }: TabViewerProps) {
   const setHighlightedNotes = useAppStore((s) => s.setHighlightedNotes);
   const [selectedBeatId, setSelectedBeatId] = useState<string | null>(null);
   const [playheadMeasureIndex, setPlayheadMeasureIndex] = useState(0);
@@ -99,6 +100,25 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
   const bpm = tabData.automations?.tempo?.[0]?.bpm;
   const effectiveBpm = typeof bpm === 'number' && bpm > 0 ? bpm : 120;
   const measureCount = tabData.measures?.length ?? 0;
+  const beatSequence = useMemo(() => {
+    const sequence: Array<{ measureIndex: number; beatIndex: number; beat: TabBeat }> = [];
+    for (let measureIndex = 0; measureIndex < measureCount; measureIndex += 1) {
+      const beats = getBeatsFromMeasure(tabData.measures[measureIndex]);
+      for (let beatIndex = 0; beatIndex < beats.length; beatIndex += 1) {
+        sequence.push({ measureIndex, beatIndex, beat: beats[beatIndex] });
+      }
+    }
+    return sequence;
+  }, [measureCount, tabData.measures]);
+  const selectedBeatSequenceIndex = useMemo(
+    () =>
+      selectedBeatId
+        ? beatSequence.findIndex(
+            ({ measureIndex, beatIndex }) => `${measureIndex}:${beatIndex}` === selectedBeatId,
+          )
+        : -1,
+    [beatSequence, selectedBeatId],
+  );
 
   const handleBeatClick = useCallback(
     (beat: TabBeat, beatId: string) => {
@@ -109,6 +129,73 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
       if (!Number.isNaN(measureIdx)) setPlayheadMeasureIndex(measureIdx);
     },
     [setHighlightedNotes],
+  );
+
+  const moveBeatSelection = useCallback(
+    (direction: -1 | 1) => {
+      if (beatSequence.length === 0) return;
+      setIsPlaying(false);
+
+      let nextIndex = -1;
+      if (selectedBeatSequenceIndex >= 0) {
+        nextIndex = selectedBeatSequenceIndex + direction;
+      } else {
+        const firstAtOrAfterPlayhead = beatSequence.findIndex(
+          ({ measureIndex }) => measureIndex >= playheadMeasureIndex,
+        );
+        if (direction > 0) {
+          nextIndex = firstAtOrAfterPlayhead >= 0 ? firstAtOrAfterPlayhead : 0;
+        } else {
+          nextIndex = firstAtOrAfterPlayhead > 0 ? firstAtOrAfterPlayhead - 1 : beatSequence.length - 1;
+        }
+      }
+
+      if (nextIndex < 0 || nextIndex >= beatSequence.length) return;
+      const next = beatSequence[nextIndex];
+      const beatId = `${next.measureIndex}:${next.beatIndex}`;
+      setSelectedBeatId(beatId);
+      setPlayheadMeasureIndex(next.measureIndex);
+      setHighlightedNotes(toHighlightedNotes(next.beat));
+    },
+    [beatSequence, playheadMeasureIndex, selectedBeatSequenceIndex, setHighlightedNotes],
+  );
+
+  const moveMeasureSelection = useCallback(
+    (direction: -1 | 1) => {
+      if (measureCount === 0) return;
+      setIsPlaying(false);
+
+      let sourceMeasureIndex = playheadMeasureIndex;
+      let sourceBeatIndex = 0;
+      if (selectedBeatId) {
+        const [measurePart, beatPart] = selectedBeatId.split(':');
+        const parsedMeasure = Number(measurePart);
+        const parsedBeat = Number(beatPart);
+        if (!Number.isNaN(parsedMeasure)) sourceMeasureIndex = parsedMeasure;
+        if (!Number.isNaN(parsedBeat)) sourceBeatIndex = parsedBeat;
+      }
+
+      const targetMeasureIndex = Math.max(
+        0,
+        Math.min(measureCount - 1, sourceMeasureIndex + direction),
+      );
+      if (targetMeasureIndex === sourceMeasureIndex) return;
+
+      const targetBeats = getBeatsFromMeasure(tabData.measures[targetMeasureIndex]);
+      setPlayheadMeasureIndex(targetMeasureIndex);
+
+      if (targetBeats.length === 0) {
+        setSelectedBeatId(null);
+        setHighlightedNotes([]);
+        return;
+      }
+
+      const targetBeatIndex = Math.min(sourceBeatIndex, targetBeats.length - 1);
+      const targetBeat = targetBeats[targetBeatIndex];
+      setSelectedBeatId(`${targetMeasureIndex}:${targetBeatIndex}`);
+      setHighlightedNotes(toHighlightedNotes(targetBeat));
+    },
+    [measureCount, playheadMeasureIndex, selectedBeatId, setHighlightedNotes, tabData.measures],
   );
 
   const stepToPrevMeasure = useCallback(() => {
@@ -177,6 +264,42 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
   }, [effectiveBpm, isPlaying, measureCount, playheadMeasureIndex, tabData.measures]);
 
   useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tagName = target.tagName;
+        if (
+          target.isContentEditable ||
+          tagName === 'INPUT' ||
+          tagName === 'TEXTAREA' ||
+          tagName === 'SELECT'
+        ) {
+          return;
+        }
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        moveBeatSelection(-1);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        moveBeatSelection(1);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        moveMeasureSelection(-1);
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        moveMeasureSelection(1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [moveBeatSelection, moveMeasureSelection]);
+
+  useEffect(() => {
     if (!measureCount) return;
     const measureEl = document.querySelector(`[data-measure-index="${playheadMeasureIndex}"]`);
     if (measureEl instanceof HTMLElement) {
@@ -217,7 +340,7 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
             {tabData.name || 'Tab Viewer'}
           </h3>
           <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
-            Click any beat to highlight those notes on the fretboard.
+            Click any beat to highlight those notes on the fretboard. Use ←/→ for beats and ↑/↓ for measures.
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -318,6 +441,7 @@ export function TabViewer({ tabData, measuresPerRow = 4 }: TabViewerProps) {
                 canStepPrev={playheadMeasureIndex > 0}
                 onStepPrev={stepToPrevMeasure}
                 onBeatClick={handleBeatClick}
+                tuningNotes={tuningNotes}
               />
             </div>
           );

--- a/frontend/src/components/TabViewer/index.ts
+++ b/frontend/src/components/TabViewer/index.ts
@@ -1,0 +1,1 @@
+export { TabViewer } from './TabViewer';

--- a/frontend/src/components/TuningSelector/TuningSelector.tsx
+++ b/frontend/src/components/TuningSelector/TuningSelector.tsx
@@ -1,0 +1,52 @@
+import type { TuningInfo } from '../../types';
+
+interface TuningSelectorProps {
+  selectedTuning: string;
+  tunings: TuningInfo[];
+  customTuningNotes: string[] | null;
+  onSelect: (tuningId: string) => void;
+}
+
+export function TuningSelector({
+  selectedTuning,
+  tunings,
+  customTuningNotes,
+  onSelect,
+}: TuningSelectorProps) {
+  const isCustom = selectedTuning === 'custom';
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        className="text-[10px] md:text-xs font-semibold uppercase tracking-wide"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        Tuning
+      </label>
+      <select
+        value={selectedTuning}
+        onChange={(e) => onSelect(e.target.value)}
+        disabled={isCustom}
+        className="px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer touch-target"
+        style={{
+          backgroundColor: 'var(--bg-input)',
+          borderColor: 'var(--border-primary)',
+          color: 'var(--text-primary)',
+          // @ts-expect-error CSS custom property
+          '--tw-ring-color': 'var(--accent-500)',
+        }}
+      >
+        {tunings.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.name} ({[...t.notes].reverse().join(' ')})
+          </option>
+        ))}
+        {isCustom && customTuningNotes && (
+          <option value="custom">
+            Custom ({[...customTuningNotes].reverse().join(' ')})
+          </option>
+        )}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/TuningSelector/TuningSelector.tsx
+++ b/frontend/src/components/TuningSelector/TuningSelector.tsx
@@ -27,7 +27,7 @@ export function TuningSelector({
         value={selectedTuning}
         onChange={(e) => onSelect(e.target.value)}
         disabled={isCustom}
-        className="px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer touch-target"
+        className="w-full min-w-[180px] md:w-[280px] px-3 md:px-4 py-2 border rounded-lg text-sm font-semibold focus:outline-none focus:ring-2 transition-all cursor-pointer touch-target"
         style={{
           backgroundColor: 'var(--bg-input)',
           borderColor: 'var(--border-primary)',

--- a/frontend/src/components/TuningSelector/index.ts
+++ b/frontend/src/components/TuningSelector/index.ts
@@ -1,0 +1,1 @@
+export { TuningSelector } from './TuningSelector';

--- a/frontend/src/components/layout/ControlBar.tsx
+++ b/frontend/src/components/layout/ControlBar.tsx
@@ -2,6 +2,7 @@ import { ScaleSelector } from '../ScaleSelector/ScaleSelector';
 import { ChordSelector } from '../ChordSelector/ChordSelector';
 import { DiatonicChordsRow } from '../DiatonicChordsRow/DiatonicChordsRow';
 import { PlayTextButton } from '../PlayButton';
+import { SongControls } from '../SongControls';
 import { playChord, getChordDuration } from '../../utils/audio';
 import { useAppStore } from '../../stores';
 import type { DiatonicChord } from '../../types';
@@ -63,6 +64,10 @@ export function ControlBar({
           boxShadow: 'var(--shadow-md)',
         }}
       >
+        {appMode === 'song' ? (
+          <SongControls />
+        ) : (
+          <>
         <div className="flex flex-wrap items-center gap-3 md:gap-6">
           {/* Scale Mode Controls */}
           {appMode === 'scale' && (
@@ -162,6 +167,8 @@ export function ControlBar({
             </button>
           )}
         </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/components/layout/ControlBar.tsx
+++ b/frontend/src/components/layout/ControlBar.tsx
@@ -63,7 +63,7 @@ export function ControlBar({
   return (
     <section className="px-3 md:px-6 pt-3 md:pt-6 pb-2 z-10 flex-shrink-0">
       <div
-        className="flex flex-col md:flex-row md:items-center justify-between gap-3 md:gap-0 px-3 md:px-6 py-3 md:py-4 rounded-xl border"
+        className="w-full rounded-xl border px-3 py-3 md:px-6 md:py-4"
         style={{
           backgroundColor: 'var(--card-bg)',
           borderColor: 'var(--border-primary)',
@@ -73,123 +73,122 @@ export function ControlBar({
         {appMode === 'song' ? (
           <SongControls />
         ) : (
-          <>
-        <div className="flex flex-wrap items-center gap-3 md:gap-6">
-          {/* Tuning Selector (scale & chord modes) */}
-          {availableTunings.length > 0 && (
-            <>
-              <TuningSelector
-                selectedTuning={selectedTuning}
-                tunings={availableTunings}
-                customTuningNotes={customTuningNotes}
-                onSelect={setSelectedTuning}
-              />
-              <div
-                className="hidden md:block h-10 w-px"
-                style={{ backgroundColor: 'var(--border-primary)' }}
-              />
-            </>
-          )}
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-3 md:gap-4">
+              <div className="flex flex-wrap items-end gap-3 md:gap-4 min-w-0">
+                {availableTunings.length > 0 && (
+                  <>
+                    <TuningSelector
+                      selectedTuning={selectedTuning}
+                      tunings={availableTunings}
+                      customTuningNotes={customTuningNotes}
+                      onSelect={setSelectedTuning}
+                    />
+                    <div
+                      className="hidden md:block h-10 w-px"
+                      style={{ backgroundColor: 'var(--border-primary)' }}
+                    />
+                  </>
+                )}
 
-          {/* Scale Mode Controls */}
-          {appMode === 'scale' && (
-            <>
-              <ScaleSelector
-                selectedRoot={selectedRoot}
-                selectedMode={selectedMode}
-                onSelect={onScaleSelect}
-                darkMode={darkMode}
-              />
-
-              {/* Diatonic Chords */}
-              {scaleData && (
-                <>
-                  <div
-                    className="hidden md:block h-10 w-px"
-                    style={{ backgroundColor: 'var(--border-primary)' }}
+                {appMode === 'scale' && (
+                  <ScaleSelector
+                    selectedRoot={selectedRoot}
+                    selectedMode={selectedMode}
+                    onSelect={onScaleSelect}
+                    darkMode={darkMode}
                   />
-                  <div className="w-full md:w-auto overflow-x-auto md:overflow-x-visible -mx-3 px-3 md:mx-0 md:px-0">
-                    <DiatonicChordsRow
-                      chords={scaleData.diatonic_chords}
-                      onChordClick={onDiatonicChordClick}
-                      selectedChord={selectedDiatonicChord}
+                )}
+
+                {appMode === 'chord' && (
+                  <>
+                    <ChordSelector
+                      selectedRoot={selectedChordRoot}
+                      selectedQuality={selectedChordQuality}
+                      onSelect={onDirectChordSelect}
                       darkMode={darkMode}
                     />
-                  </div>
-                </>
-              )}
-            </>
-          )}
-
-          {/* Chord Mode Controls */}
-          {appMode === 'chord' && (
-            <>
-              <ChordSelector
-                selectedRoot={selectedChordRoot}
-                selectedQuality={selectedChordQuality}
-                onSelect={onDirectChordSelect}
-                darkMode={darkMode}
-              />
-              <div className="flex items-center gap-2">
-                <span
-                  className="text-xs md:text-sm"
-                  style={{ color: scaleData ? 'var(--text-secondary)' : 'var(--text-muted)' }}
-                >
-                  Show Scale Overlay
-                </span>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={showScaleInChordMode}
-                  aria-label="Show Scale Overlay"
-                  onClick={() => scaleData && setShowScaleInChordMode(!showScaleInChordMode)}
-                  disabled={!scaleData}
-                  className={`
-                    relative inline-flex h-6 w-11 items-center rounded-full border transition-colors
-                    ${showScaleInChordMode ? '' : ''}
-                    ${scaleData ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}
-                  `}
-                  style={{
-                    backgroundColor: showScaleInChordMode ? 'var(--accent-500)' : 'var(--bg-tertiary)',
-                    borderColor: showScaleInChordMode ? 'var(--accent-600)' : 'var(--border-primary)',
-                  }}
-                >
-                  <span
-                    className={`
-                      inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform
-                      ${showScaleInChordMode ? 'translate-x-5' : 'translate-x-0.5'}
-                    `}
-                  />
-                </button>
+                    <div className="flex flex-col gap-1">
+                      <span
+                        className="text-[10px] md:text-xs font-semibold uppercase tracking-wide"
+                        style={{ color: 'var(--text-muted)' }}
+                      >
+                        Overlay
+                      </span>
+                      <div className="flex items-center gap-2 min-h-[42px]">
+                        <span
+                          className="text-xs md:text-sm whitespace-nowrap"
+                          style={{ color: scaleData ? 'var(--text-secondary)' : 'var(--text-muted)' }}
+                        >
+                          Show Scale
+                        </span>
+                        <button
+                          type="button"
+                          role="switch"
+                          aria-checked={showScaleInChordMode}
+                          aria-label="Show Scale Overlay"
+                          onClick={() => scaleData && setShowScaleInChordMode(!showScaleInChordMode)}
+                          disabled={!scaleData}
+                          className={`
+                            relative inline-flex h-6 w-11 items-center rounded-full border transition-colors
+                            ${showScaleInChordMode ? '' : ''}
+                            ${scaleData ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}
+                          `}
+                          style={{
+                            backgroundColor: showScaleInChordMode ? 'var(--accent-500)' : 'var(--bg-tertiary)',
+                            borderColor: showScaleInChordMode ? 'var(--accent-600)' : 'var(--border-primary)',
+                          }}
+                        >
+                          <span
+                            className={`
+                              inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform
+                              ${showScaleInChordMode ? 'translate-x-5' : 'translate-x-0.5'}
+                            `}
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
-            </>
-          )}
-        </div>
 
-        {/* Right side actions */}
-        <div className="flex items-center gap-2 md:gap-3">
-          {showPlayButton && (
-            <PlayTextButton
-              onClick={handlePlayChord}
-              duration={getChordDuration(5) * 1000}
-              label="Play Chord"
-            />
-          )}
-          {showClearButton && (
-            <button
-              onClick={onClearAll}
-              className="px-3 md:px-4 py-2 rounded-lg text-xs md:text-sm font-medium transition-all border touch-target"
-              style={{
-                backgroundColor: 'var(--card-bg)',
-                borderColor: 'var(--border-primary)',
-                color: 'var(--text-secondary)',
-              }}
-            >
-              Clear
-            </button>
-          )}
-        </div>
-          </>
+              <div className="flex items-center gap-2 md:gap-3">
+                {showPlayButton && (
+                  <PlayTextButton
+                    onClick={handlePlayChord}
+                    duration={getChordDuration(5) * 1000}
+                    label="Play Chord"
+                  />
+                )}
+                {showClearButton && (
+                  <button
+                    onClick={onClearAll}
+                    className="px-3 md:px-4 py-2 rounded-lg text-xs md:text-sm font-medium transition-all border touch-target"
+                    style={{
+                      backgroundColor: 'var(--card-bg)',
+                      borderColor: 'var(--border-primary)',
+                      color: 'var(--text-secondary)',
+                    }}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {appMode === 'scale' && scaleData && (
+              <div className="border-t pt-4" style={{ borderColor: 'var(--border-primary)' }}>
+                <div className="w-full overflow-x-auto md:overflow-x-visible">
+                  <DiatonicChordsRow
+                    chords={scaleData.diatonic_chords}
+                    onChordClick={onDiatonicChordClick}
+                    selectedChord={selectedDiatonicChord}
+                    darkMode={darkMode}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </section>

--- a/frontend/src/components/layout/ControlBar.tsx
+++ b/frontend/src/components/layout/ControlBar.tsx
@@ -1,5 +1,6 @@
 import { ScaleSelector } from '../ScaleSelector/ScaleSelector';
 import { ChordSelector } from '../ChordSelector/ChordSelector';
+import { TuningSelector } from '../TuningSelector';
 import { DiatonicChordsRow } from '../DiatonicChordsRow/DiatonicChordsRow';
 import { PlayTextButton } from '../PlayButton';
 import { SongControls } from '../SongControls';
@@ -35,6 +36,11 @@ export function ControlBar({
     activeVoicings,
     showScaleInChordMode,
     setShowScaleInChordMode,
+    // Tuning state
+    selectedTuning,
+    customTuningNotes,
+    availableTunings,
+    setSelectedTuning,
   } = useAppStore();
 
   const showClearButton = scaleData || chordData;
@@ -69,6 +75,22 @@ export function ControlBar({
         ) : (
           <>
         <div className="flex flex-wrap items-center gap-3 md:gap-6">
+          {/* Tuning Selector (scale & chord modes) */}
+          {availableTunings.length > 0 && (
+            <>
+              <TuningSelector
+                selectedTuning={selectedTuning}
+                tunings={availableTunings}
+                customTuningNotes={customTuningNotes}
+                onSelect={setSelectedTuning}
+              />
+              <div
+                className="hidden md:block h-10 w-px"
+                style={{ backgroundColor: 'var(--border-primary)' }}
+              />
+            </>
+          )}
+
           {/* Scale Mode Controls */}
           {appMode === 'scale' && (
             <>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -17,11 +17,17 @@ export function Header() {
     fetchChord,
   } = useAppStore();
 
-  const showDisplayToggle = scaleData || chordData;
+  const showDisplayToggle = appMode !== 'song' && (scaleData || chordData);
 
   // Handle mode switch while preserving scale context for chord overlay rendering
-  const handleModeSwitch = useCallback(async (mode: 'scale' | 'chord') => {
+  const handleModeSwitch = useCallback(async (mode: 'scale' | 'chord' | 'song') => {
     setAppMode(mode);
+
+    if (mode === 'song') {
+      clearChord();
+      resetChord();
+      return;
+    }
 
     if (mode === 'chord') {
       clearChord();
@@ -70,7 +76,7 @@ export function Header() {
 
         {/* Right side controls */}
         <div className="flex items-center gap-2 md:gap-4">
-          {/* Mode Toggle (Scale/Chord) */}
+          {/* Mode Toggle (Scale/Chord/Songs) */}
           <div
             className="flex rounded-lg p-0.5 md:p-1 border"
             style={{ backgroundColor: 'var(--bg-tertiary)', borderColor: 'var(--border-primary)' }}
@@ -102,6 +108,20 @@ export function Header() {
             >
               <span className="hidden sm:inline">Chord Mode</span>
               <span className="sm:hidden">Chord</span>
+            </button>
+            <button
+              onClick={() => handleModeSwitch('song')}
+              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
+                appMode === 'song' ? 'shadow-sm border font-bold' : ''
+              }`}
+              style={{
+                backgroundColor: appMode === 'song' ? 'var(--card-bg)' : 'transparent',
+                borderColor: appMode === 'song' ? 'var(--border-primary)' : 'transparent',
+                color: appMode === 'song' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+            >
+              <span className="hidden sm:inline">Songs</span>
+              <span className="sm:hidden">Song</span>
             </button>
           </div>
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -76,55 +76,6 @@ export function Header() {
 
         {/* Right side controls */}
         <div className="flex items-center gap-2 md:gap-4">
-          {/* Mode Toggle (Scale/Chord/Songs) */}
-          <div
-            className="flex rounded-lg p-0.5 md:p-1 border"
-            style={{ backgroundColor: 'var(--bg-tertiary)', borderColor: 'var(--border-primary)' }}
-          >
-            <button
-              onClick={() => handleModeSwitch('scale')}
-              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
-                appMode === 'scale' ? 'shadow-sm border font-bold' : ''
-              }`}
-              style={{
-                backgroundColor: appMode === 'scale' ? 'var(--card-bg)' : 'transparent',
-                borderColor: appMode === 'scale' ? 'var(--border-primary)' : 'transparent',
-                color: appMode === 'scale' ? 'var(--accent-600)' : 'var(--text-tertiary)',
-              }}
-            >
-              <span className="hidden sm:inline">Scale Mode</span>
-              <span className="sm:hidden">Scale</span>
-            </button>
-            <button
-              onClick={() => handleModeSwitch('chord')}
-              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
-                appMode === 'chord' ? 'shadow-sm border font-bold' : ''
-              }`}
-              style={{
-                backgroundColor: appMode === 'chord' ? 'var(--card-bg)' : 'transparent',
-                borderColor: appMode === 'chord' ? 'var(--border-primary)' : 'transparent',
-                color: appMode === 'chord' ? 'var(--accent-600)' : 'var(--text-tertiary)',
-              }}
-            >
-              <span className="hidden sm:inline">Chord Mode</span>
-              <span className="sm:hidden">Chord</span>
-            </button>
-            <button
-              onClick={() => handleModeSwitch('song')}
-              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
-                appMode === 'song' ? 'shadow-sm border font-bold' : ''
-              }`}
-              style={{
-                backgroundColor: appMode === 'song' ? 'var(--card-bg)' : 'transparent',
-                borderColor: appMode === 'song' ? 'var(--border-primary)' : 'transparent',
-                color: appMode === 'song' ? 'var(--accent-600)' : 'var(--text-tertiary)',
-              }}
-            >
-              <span className="hidden sm:inline">Songs</span>
-              <span className="sm:hidden">Song</span>
-            </button>
-          </div>
-
           {/* Display Mode Toggle */}
           {showDisplayToggle && (
             <div
@@ -166,6 +117,55 @@ export function Header() {
               </button>
             </div>
           )}
+
+          {/* Mode Toggle (Scale/Chord/Songs) */}
+          <div
+            className="flex rounded-lg p-0.5 md:p-1 border"
+            style={{ backgroundColor: 'var(--bg-tertiary)', borderColor: 'var(--border-primary)' }}
+          >
+            <button
+              onClick={() => handleModeSwitch('scale')}
+              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
+                appMode === 'scale' ? 'shadow-sm border font-bold' : ''
+              }`}
+              style={{
+                backgroundColor: appMode === 'scale' ? 'var(--card-bg)' : 'transparent',
+                borderColor: appMode === 'scale' ? 'var(--border-primary)' : 'transparent',
+                color: appMode === 'scale' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+            >
+              <span className="hidden sm:inline">Scales</span>
+              <span className="sm:hidden">Scale</span>
+            </button>
+            <button
+              onClick={() => handleModeSwitch('chord')}
+              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
+                appMode === 'chord' ? 'shadow-sm border font-bold' : ''
+              }`}
+              style={{
+                backgroundColor: appMode === 'chord' ? 'var(--card-bg)' : 'transparent',
+                borderColor: appMode === 'chord' ? 'var(--border-primary)' : 'transparent',
+                color: appMode === 'chord' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+            >
+              <span className="hidden sm:inline">Chords</span>
+              <span className="sm:hidden">Chord</span>
+            </button>
+            <button
+              onClick={() => handleModeSwitch('song')}
+              className={`px-2 md:px-4 py-1 md:py-1.5 rounded-md text-xs md:text-sm font-medium transition-all touch-target ${
+                appMode === 'song' ? 'shadow-sm border font-bold' : ''
+              }`}
+              style={{
+                backgroundColor: appMode === 'song' ? 'var(--card-bg)' : 'transparent',
+                borderColor: appMode === 'song' ? 'var(--border-primary)' : 'transparent',
+                color: appMode === 'song' ? 'var(--accent-600)' : 'var(--text-tertiary)',
+              }}
+            >
+              <span className="hidden sm:inline">Songs</span>
+              <span className="sm:hidden">Song</span>
+            </button>
+          </div>
 
           {/* Dark Mode Toggle */}
           <button

--- a/frontend/src/hooks/useFretboard.ts
+++ b/frontend/src/hooks/useFretboard.ts
@@ -8,7 +8,7 @@ interface UseFretboardResult {
   error: string | null;
 }
 
-export function useFretboard(tuning: string = 'standard'): UseFretboardResult {
+export function useFretboard(tuning: string = 'standard', tuningNotes?: string): UseFretboardResult {
   const [fretboardData, setFretboardData] = useState<FretboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -17,7 +17,7 @@ export function useFretboard(tuning: string = 'standard'): UseFretboardResult {
     async function fetchFretboard() {
       try {
         setLoading(true);
-        const data = await apiClient.getFretboard(tuning);
+        const data = await apiClient.getFretboard(tuning, tuningNotes);
         setFretboardData(data);
         setError(null);
       } catch (err) {
@@ -29,7 +29,7 @@ export function useFretboard(tuning: string = 'standard'): UseFretboardResult {
     }
 
     fetchFretboard();
-  }, [tuning]);
+  }, [tuning, tuningNotes]);
 
   return { fretboardData, loading, error };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
-/* Import Inter font - must be first */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
+/* Import app + tab fonts - must be first */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 @import "tailwindcss";
 

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -11,8 +11,10 @@ import type {
   TabDataResponse,
   ChordProResponse,
   HighlightedNote,
+  TuningInfo,
 } from '../types';
 import type { ChatMessage } from '../types/chat';
+import { midiTuningToNotes, matchTuningId } from '../utils/tuning';
 
 // App mode type
 export type AppMode = 'scale' | 'chord' | 'song';
@@ -201,9 +203,21 @@ interface SongSlice {
 }
 
 // ============================================================================
+// Tuning Slice
+// ============================================================================
+interface TuningSlice {
+  selectedTuning: string;
+  customTuningNotes: string[] | null;
+  availableTunings: TuningInfo[];
+  setSelectedTuning: (tuning: string) => void;
+  setCustomTuningNotes: (notes: string[] | null) => void;
+  fetchTunings: () => Promise<void>;
+}
+
+// ============================================================================
 // Combined Store Type
 // ============================================================================
-type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice & SongSlice;
+type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice & SongSlice & TuningSlice;
 
 // ============================================================================
 // Store Implementation
@@ -244,7 +258,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
   diagramsExpanded: false,
   popupState: null,
   
-  setAppMode: (mode) => set({ appMode: mode }),
+  setAppMode: (mode) => {
+    const prev = get().appMode;
+    // Reset tuning to standard when leaving song mode
+    if (prev === 'song' && mode !== 'song') {
+      set({ appMode: mode, selectedTuning: 'standard', customTuningNotes: null });
+    } else {
+      set({ appMode: mode });
+    }
+  },
   setDisplayMode: (mode) => set({ displayMode: mode }),
   setShowScaleInChordMode: (show) => set({ showScaleInChordMode: show }),
   setDiagramsExpanded: (expanded) => set({ diagramsExpanded: expanded }),
@@ -268,13 +290,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
   fetchScale: async (root, mode) => {
     set({ scaleLoading: true, scaleError: null, selectedRoot: root, selectedMode: mode });
     try {
-      const data = await apiClient.getScale(root, mode);
+      const { selectedTuning, customTuningNotes } = get();
+      const tuningNotes = customTuningNotes?.join(',');
+      const data = await apiClient.getScale(root, mode, selectedTuning, tuningNotes);
       set({ scaleData: data, selectedDiatonicChord: null, scaleLoading: false });
     } catch (err) {
       console.error('Failed to fetch scale:', err);
-      set({ 
+      set({
         scaleError: err instanceof Error ? err.message : 'Failed to load scale',
-        scaleLoading: false 
+        scaleLoading: false
       });
     }
   },
@@ -319,20 +343,22 @@ export const useAppStore = create<AppStore>((set, get) => ({
   fetchChord: async (root, quality) => {
     set({ chordLoading: true, chordError: null });
     try {
-      const data = await apiClient.getChord(root, quality);
-      set({ 
-        chordData: data, 
+      const { selectedTuning, customTuningNotes } = get();
+      const tuningNotes = customTuningNotes?.join(',');
+      const data = await apiClient.getChord(root, quality, selectedTuning, tuningNotes);
+      set({
+        chordData: data,
         selectedChordRoot: root,
         selectedChordQuality: quality,
         activeVoicings: [],
-        chordLoading: false 
+        chordLoading: false
       });
       return data;
     } catch (err) {
       console.error('Failed to fetch chord:', err);
-      set({ 
+      set({
         chordError: err instanceof Error ? err.message : 'Failed to load chord',
-        chordLoading: false 
+        chordLoading: false
       });
       return null;
     }
@@ -510,6 +536,34 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setMobileSheetOpen: (open) => set({ mobileSheetOpen: open }),
 
   // --------------------------------------------------------------------------
+  // Tuning Slice
+  // --------------------------------------------------------------------------
+  selectedTuning: 'standard',
+  customTuningNotes: null,
+  availableTunings: [],
+
+  setSelectedTuning: (tuning) => set({ selectedTuning: tuning, customTuningNotes: null }),
+  setCustomTuningNotes: (notes) => set({ customTuningNotes: notes }),
+  fetchTunings: async () => {
+    try {
+      const data = await apiClient.getTunings();
+      set({ availableTunings: data.tunings });
+
+      // If currently in 'custom' tuning (e.g. song loaded before tunings arrived),
+      // retry matching against the now-loaded tunings
+      const { selectedTuning, customTuningNotes } = get();
+      if (selectedTuning === 'custom' && customTuningNotes) {
+        const matched = matchTuningId(customTuningNotes, data.tunings);
+        if (matched) {
+          set({ selectedTuning: matched, customTuningNotes: null });
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch tunings:', err);
+    }
+  },
+
+  // --------------------------------------------------------------------------
   // Song Slice
   // --------------------------------------------------------------------------
   songSearchQuery: '',
@@ -563,6 +617,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // Find first non-vocal, non-empty track
       const defaultTrack = tracksData.tracks.find(t => !t.is_vocal && !t.is_empty);
       const trackIdx = defaultTrack ? defaultTrack.index : 0;
+      const selectedTrack = tracksData.tracks.find(t => t.index === trackIdx);
+
+      // Auto-detect tuning from track
+      if (selectedTrack?.tuning) {
+        const notes = midiTuningToNotes(selectedTrack.tuning);
+        const matched = matchTuningId(notes, get().availableTunings);
+        if (matched) {
+          set({ selectedTuning: matched, customTuningNotes: null });
+        } else {
+          set({ selectedTuning: 'custom', customTuningNotes: notes });
+        }
+      } else {
+        set({ selectedTuning: 'standard', customTuningNotes: null });
+      }
 
       const tabData = await apiClient.getTabData(song.song_id, trackIdx);
       set({ tabData, selectedTrackIndex: trackIdx, tabLoading: false });
@@ -576,9 +644,24 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   selectTrack: async (index) => {
-    const { selectedSong } = get();
+    const { selectedSong, songTracks, availableTunings } = get();
     if (!selectedSong) return;
     set({ selectedTrackIndex: index, tabLoading: true, tabError: null, highlightedNotes: [] });
+
+    // Auto-detect tuning from new track
+    const track = songTracks?.tracks.find(t => t.index === index);
+    if (track?.tuning) {
+      const notes = midiTuningToNotes(track.tuning);
+      const matched = matchTuningId(notes, availableTunings);
+      if (matched) {
+        set({ selectedTuning: matched, customTuningNotes: null });
+      } else {
+        set({ selectedTuning: 'custom', customTuningNotes: notes });
+      }
+    } else {
+      set({ selectedTuning: 'standard', customTuningNotes: null });
+    }
+
     try {
       const tabData = await apiClient.getTabData(selectedSong.song_id, index);
       set({ tabData, tabLoading: false });
@@ -701,3 +784,8 @@ export const useTabLoading = () => useAppStore((state) => state.tabLoading);
 export const useTabError = () => useAppStore((state) => state.tabError);
 export const useSongViewMode = () => useAppStore((state) => state.songViewMode);
 export const useHighlightedNotes = () => useAppStore((state) => state.highlightedNotes);
+
+// Tuning selectors
+export const useSelectedTuning = () => useAppStore((state) => state.selectedTuning);
+export const useAvailableTunings = () => useAppStore((state) => state.availableTunings);
+export const useCustomTuningNotes = () => useAppStore((state) => state.customTuningNotes);

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -1,15 +1,21 @@
 import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 import { apiClient, nodeLabel } from '../api/client';
 import type {
-  ScaleResponse, 
-  ChordResponse, 
-  DiatonicChord, 
-  DisplayMode 
+  ScaleResponse,
+  ChordResponse,
+  DiatonicChord,
+  DisplayMode,
+  SongSearchResult,
+  SongTracksResponse,
+  TabDataResponse,
+  ChordProResponse,
+  HighlightedNote,
 } from '../types';
 import type { ChatMessage } from '../types/chat';
 
 // App mode type
-export type AppMode = 'scale' | 'chord';
+export type AppMode = 'scale' | 'chord' | 'song';
 
 // Generate unique message IDs
 function generateMessageId(): string {
@@ -153,9 +159,51 @@ interface ChatPanelSlice {
 }
 
 // ============================================================================
+// Song Slice
+// ============================================================================
+interface SongSlice {
+  // Search
+  songSearchQuery: string;
+  songSearchResults: SongSearchResult[];
+  songSearchLoading: boolean;
+  songSearchError: string | null;
+
+  // Selected song & tracks
+  selectedSong: SongSearchResult | null;
+  songTracks: SongTracksResponse | null;
+  selectedTrackIndex: number;
+
+  // Tab data
+  tabData: TabDataResponse | null;
+  tabLoading: boolean;
+  tabError: string | null;
+
+  // ChordPro
+  chordProData: ChordProResponse | null;
+  chordProLoading: boolean;
+
+  // View mode within song mode
+  songViewMode: 'tab' | 'chords';
+
+  // Bridge: highlighted notes on fretboard
+  highlightedNotes: HighlightedNote[];
+
+  // Actions
+  searchSongs: (query: string) => Promise<void>;
+  selectSong: (song: SongSearchResult) => Promise<void>;
+  selectTrack: (index: number) => Promise<void>;
+  fetchChordPro: (songId: number) => Promise<void>;
+  setSongViewMode: (mode: 'tab' | 'chords') => void;
+  setHighlightedNotes: (notes: HighlightedNote[]) => void;
+  clearHighlightedNotes: () => void;
+  clearSongState: () => void;
+  backToSearch: () => void;
+}
+
+// ============================================================================
 // Combined Store Type
 // ============================================================================
-type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice;
+type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice & SongSlice;
 
 // ============================================================================
 // Store Implementation
@@ -460,6 +508,131 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setChatWidth: (width) => set({ chatWidth: width }),
   toggleCollapsed: () => set((state) => ({ chatCollapsed: !state.chatCollapsed })),
   setMobileSheetOpen: (open) => set({ mobileSheetOpen: open }),
+
+  // --------------------------------------------------------------------------
+  // Song Slice
+  // --------------------------------------------------------------------------
+  songSearchQuery: '',
+  songSearchResults: [],
+  songSearchLoading: false,
+  songSearchError: null,
+
+  selectedSong: null,
+  songTracks: null,
+  selectedTrackIndex: 0,
+
+  tabData: null,
+  tabLoading: false,
+  tabError: null,
+
+  chordProData: null,
+  chordProLoading: false,
+
+  songViewMode: 'tab',
+  highlightedNotes: [],
+
+  searchSongs: async (query) => {
+    set({ songSearchLoading: true, songSearchError: null, songSearchQuery: query });
+    try {
+      const data = await apiClient.searchSongs(query);
+      set({ songSearchResults: data.results, songSearchLoading: false });
+    } catch (err) {
+      console.error('Failed to search songs:', err);
+      set({
+        songSearchError: err instanceof Error ? err.message : 'Failed to search songs',
+        songSearchLoading: false,
+      });
+    }
+  },
+
+  selectSong: async (song) => {
+    set({
+      selectedSong: song,
+      tabLoading: true,
+      tabError: null,
+      tabData: null,
+      chordProData: null,
+      selectedTrackIndex: 0,
+      songViewMode: 'tab',
+      highlightedNotes: [],
+    });
+    try {
+      const tracksData = await apiClient.getSongTracks(song.song_id);
+      set({ songTracks: tracksData });
+
+      // Find first non-vocal, non-empty track
+      const defaultTrack = tracksData.tracks.find(t => !t.is_vocal && !t.is_empty);
+      const trackIdx = defaultTrack ? defaultTrack.index : 0;
+
+      const tabData = await apiClient.getTabData(song.song_id, trackIdx);
+      set({ tabData, selectedTrackIndex: trackIdx, tabLoading: false });
+    } catch (err) {
+      console.error('Failed to load song:', err);
+      set({
+        tabError: err instanceof Error ? err.message : 'Failed to load song',
+        tabLoading: false,
+      });
+    }
+  },
+
+  selectTrack: async (index) => {
+    const { selectedSong } = get();
+    if (!selectedSong) return;
+    set({ selectedTrackIndex: index, tabLoading: true, tabError: null, highlightedNotes: [] });
+    try {
+      const tabData = await apiClient.getTabData(selectedSong.song_id, index);
+      set({ tabData, tabLoading: false });
+    } catch (err) {
+      console.error('Failed to load track:', err);
+      set({
+        tabError: err instanceof Error ? err.message : 'Failed to load track',
+        tabLoading: false,
+      });
+    }
+  },
+
+  fetchChordPro: async (songId) => {
+    set({ chordProLoading: true });
+    try {
+      const data = await apiClient.getChordPro(songId);
+      set({ chordProData: data, chordProLoading: false });
+    } catch {
+      set({ chordProData: null, chordProLoading: false });
+    }
+  },
+
+  setSongViewMode: (mode) => set({ songViewMode: mode }),
+  setHighlightedNotes: (notes) => set({ highlightedNotes: notes }),
+  clearHighlightedNotes: () => set({ highlightedNotes: [] }),
+
+  clearSongState: () => set({
+    songSearchQuery: '',
+    songSearchResults: [],
+    songSearchLoading: false,
+    songSearchError: null,
+    selectedSong: null,
+    songTracks: null,
+    selectedTrackIndex: 0,
+    tabData: null,
+    tabLoading: false,
+    tabError: null,
+    chordProData: null,
+    chordProLoading: false,
+    songViewMode: 'tab',
+    highlightedNotes: [],
+  }),
+
+  backToSearch: () => set({
+    selectedSong: null,
+    songTracks: null,
+    selectedTrackIndex: 0,
+    tabData: null,
+    tabLoading: false,
+    tabError: null,
+    chordProData: null,
+    chordProLoading: false,
+    highlightedNotes: [],
+  }),
 }));
 
 // ============================================================================
@@ -477,17 +650,23 @@ export const useShowScaleInChordMode = () => useAppStore((state) => state.showSc
 
 // Scale selectors
 export const useScaleData = () => useAppStore((state) => state.scaleData);
-export const useSelectedScale = () => useAppStore((state) => ({
-  root: state.selectedRoot,
-  mode: state.selectedMode,
-}));
+export const useSelectedScale = () =>
+  useAppStore(
+    useShallow((state) => ({
+      root: state.selectedRoot,
+      mode: state.selectedMode,
+    })),
+  );
 
 // Chord selectors
 export const useChordData = () => useAppStore((state) => state.chordData);
-export const useSelectedChord = () => useAppStore((state) => ({
-  root: state.selectedChordRoot,
-  quality: state.selectedChordQuality,
-}));
+export const useSelectedChord = () =>
+  useAppStore(
+    useShallow((state) => ({
+      root: state.selectedChordRoot,
+      quality: state.selectedChordQuality,
+    })),
+  );
 export const useActiveVoicings = () => useAppStore((state) => state.activeVoicings);
 
 // Chat selectors
@@ -496,8 +675,29 @@ export const useChatLoading = () => useAppStore((state) => state.chatLoading);
 export const useStreamingStatus = () => useAppStore((state) => state.streamingStatus);
 
 // Chat panel selectors
-export const useChatPanelState = () => useAppStore((state) => ({
-  width: state.chatWidth,
-  collapsed: state.chatCollapsed,
-  mobileOpen: state.mobileSheetOpen,
-}));
+export const useChatPanelState = () =>
+  useAppStore(
+    useShallow((state) => ({
+      width: state.chatWidth,
+      collapsed: state.chatCollapsed,
+      mobileOpen: state.mobileSheetOpen,
+    })),
+  );
+
+// Song selectors
+export const useSongSearch = () =>
+  useAppStore(
+    useShallow((state) => ({
+      query: state.songSearchQuery,
+      results: state.songSearchResults,
+      loading: state.songSearchLoading,
+      error: state.songSearchError,
+    })),
+  );
+export const useSelectedSong = () => useAppStore((state) => state.selectedSong);
+export const useSongTracks = () => useAppStore((state) => state.songTracks);
+export const useTabData = () => useAppStore((state) => state.tabData);
+export const useTabLoading = () => useAppStore((state) => state.tabLoading);
+export const useTabError = () => useAppStore((state) => state.tabError);
+export const useSongViewMode = () => useAppStore((state) => state.songViewMode);
+export const useHighlightedNotes = () => useAppStore((state) => state.highlightedNotes);

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -15,7 +15,7 @@ import type {
   TabMeasure,
   TuningInfo,
 } from '../types';
-import type { ChatMessage, UiContext } from '../types/chat';
+import type { ChatMessage, UiContext, FretboardHighlightGroup } from '../types/chat';
 import { midiTuningToNotes, matchTuningId } from '../utils/tuning';
 
 // App mode type
@@ -271,9 +271,24 @@ interface TuningSlice {
 }
 
 // ============================================================================
+// Agent Highlight Slice
+// ============================================================================
+interface AgentHighlightSlice {
+  agentHighlightGroups: FretboardHighlightGroup[] | null;
+  agentHighlightIndex: number;
+  agentHighlightMessageId: string | null;
+  agentHighlightVisible: boolean;
+  setAgentHighlights: (groups: FretboardHighlightGroup[], messageId: string) => void;
+  clearAgentHighlights: () => void;
+  toggleAgentHighlightVisible: () => void;
+  nextAgentHighlight: () => void;
+  prevAgentHighlight: () => void;
+}
+
+// ============================================================================
 // Combined Store Type
 // ============================================================================
-type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice & SongSlice & TuningSlice;
+type AppStore = ThemeSlice & UISlice & ScaleSlice & ChordSlice & ChatSlice & ChatPanelSlice & SongSlice & TuningSlice & AgentHighlightSlice;
 
 // ============================================================================
 // Store Implementation
@@ -668,7 +683,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
   resetChat: () => {
     const newThreadId = generateThreadId();
     persistThread(newThreadId, []);
-    set({ messages: [], threadId: newThreadId });
+    set({
+      messages: [],
+      threadId: newThreadId,
+      agentHighlightGroups: null,
+      agentHighlightIndex: 0,
+      agentHighlightMessageId: null,
+      agentHighlightVisible: false,
+    });
   },
 
   // --------------------------------------------------------------------------
@@ -965,6 +987,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
     highlightedNotes: [],
     playheadMeasureIndex: 0,
     selectedBeatId: null,
+  }),
+
+  // --------------------------------------------------------------------------
+  // Agent Highlight Slice
+  // --------------------------------------------------------------------------
+  agentHighlightGroups: null,
+  agentHighlightIndex: 0,
+  agentHighlightMessageId: null,
+  agentHighlightVisible: false,
+
+  setAgentHighlights: (groups, messageId) => set({ agentHighlightGroups: groups, agentHighlightIndex: 0, agentHighlightMessageId: messageId, agentHighlightVisible: true }),
+
+  clearAgentHighlights: () => set({ agentHighlightGroups: null, agentHighlightIndex: 0, agentHighlightMessageId: null, agentHighlightVisible: false }),
+
+  toggleAgentHighlightVisible: () => set((state) => ({ agentHighlightVisible: !state.agentHighlightVisible })),
+
+  nextAgentHighlight: () => set((state) => {
+    if (!state.agentHighlightGroups) return {};
+    return { agentHighlightIndex: (state.agentHighlightIndex + 1) % state.agentHighlightGroups.length };
+  }),
+
+  prevAgentHighlight: () => set((state) => {
+    if (!state.agentHighlightGroups) return {};
+    const len = state.agentHighlightGroups.length;
+    return { agentHighlightIndex: (state.agentHighlightIndex - 1 + len) % len };
   }),
 }));
 

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -11,9 +11,11 @@ import type {
   TabDataResponse,
   ChordProResponse,
   HighlightedNote,
+  TabBeat,
+  TabMeasure,
   TuningInfo,
 } from '../types';
-import type { ChatMessage } from '../types/chat';
+import type { ChatMessage, UiContext } from '../types/chat';
 import { midiTuningToNotes, matchTuningId } from '../utils/tuning';
 
 // App mode type
@@ -63,6 +65,54 @@ function persistThread(threadId: string, messages: ChatMessage[]) {
     localStorage.setItem(STORAGE_KEY_THREAD, threadId);
     localStorage.setItem(STORAGE_KEY_MESSAGES, JSON.stringify(messages));
   } catch { /* storage full or unavailable */ }
+}
+
+function getBeatsFromMeasure(measure?: TabMeasure): TabBeat[] {
+  if (!measure) return [];
+  const voices = measure.voices ?? [];
+  if (voices.length === 0) return [];
+  if (voices.length === 1) return voices[0]?.beats ?? [];
+
+  let bestBeats: TabBeat[] = voices[0]?.beats ?? [];
+  let bestScore = -1;
+  for (const voice of voices) {
+    const beats = voice?.beats ?? [];
+    const score = beats.reduce((acc, beat) => {
+      const noteCount = (beat.notes ?? []).filter((n) => !n.rest && !n.dead).length;
+      return acc + noteCount;
+    }, 0);
+    if (score > bestScore) {
+      bestScore = score;
+      bestBeats = beats;
+    }
+  }
+  return bestBeats;
+}
+
+function toHighlightedNotes(beat?: TabBeat): HighlightedNote[] {
+  if (!beat) return [];
+  const seen = new Set<string>();
+  const highlights: HighlightedNote[] = [];
+  for (const note of beat.notes ?? []) {
+    if (note.rest || note.dead) continue;
+    if (typeof note.string !== 'number' || typeof note.fret !== 'number') continue;
+    const mappedString = note.string + 1;
+    if (mappedString < 1 || mappedString > 6) continue;
+
+    const key = `${mappedString}:${note.fret}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    highlights.push({ string: mappedString, fret: note.fret });
+  }
+  return highlights;
+}
+
+function firstPlayableBeatIndex(beats: TabBeat[]): number | undefined {
+  for (let i = 0; i < beats.length; i += 1) {
+    const notes = beats[i].notes ?? [];
+    if (notes.some((n) => !n.rest && !n.dead)) return i;
+  }
+  return beats.length ? 0 : undefined;
 }
 
 // ============================================================================
@@ -189,14 +239,20 @@ interface SongSlice {
 
   // Bridge: highlighted notes on fretboard
   highlightedNotes: HighlightedNote[];
+  playheadMeasureIndex: number;
+  selectedBeatId: string | null;
 
   // Actions
   searchSongs: (query: string) => Promise<void>;
   selectSong: (song: SongSearchResult) => Promise<void>;
+  selectSongById: (songId: number) => Promise<void>;
   selectTrack: (index: number) => Promise<void>;
   fetchChordPro: (songId: number) => Promise<void>;
   setSongViewMode: (mode: 'tab' | 'chords') => void;
   setHighlightedNotes: (notes: HighlightedNote[]) => void;
+  setPlayheadMeasureIndex: (index: number) => void;
+  setSelectedBeatId: (id: string | null) => void;
+  focusMeasureBeat: (measureIndex: number, beatIndex?: number) => void;
   clearHighlightedNotes: () => void;
   clearSongState: () => void;
   backToSearch: () => void;
@@ -444,10 +500,95 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     };
 
+    const buildUiContext = (): UiContext => {
+      const state = get();
+      return {
+        app_mode: state.appMode,
+        display_mode: state.displayMode,
+        selected_tuning: state.selectedTuning,
+        custom_tuning_notes: state.customTuningNotes,
+        selected_scale: state.scaleData
+          ? { root: state.selectedRoot, mode: state.selectedMode }
+          : null,
+        selected_chord: state.chordData
+          ? { root: state.selectedChordRoot, quality: state.selectedChordQuality }
+          : null,
+        selected_song: state.selectedSong
+          ? {
+              song_id: state.selectedSong.song_id,
+              artist: state.selectedSong.artist,
+              title: state.selectedSong.title,
+              has_chords: state.selectedSong.has_chords,
+            }
+          : null,
+        selected_track_index: state.selectedTrackIndex,
+        song_view_mode: state.songViewMode,
+        playhead_measure_index: state.playheadMeasureIndex,
+        selected_beat_id: state.selectedBeatId,
+        highlighted_notes: state.highlightedNotes,
+      };
+    };
+
+    const sendWithBootstrapRetry = async () => {
+      const uiContext = buildUiContext();
+      if (isResumingFromInterrupt) {
+        try {
+          return await apiClient.streamResume(message, threadId, uiContext, onStatus, onToken);
+        } catch (err) {
+          const code = (err as Error & { code?: string }).code;
+          if (code !== 'THREAD_NOT_FOUND') throw err;
+
+          console.warn('Resume thread missing on server, retrying with bootstrap history.');
+          return apiClient.streamChat(
+            message,
+            threadId,
+            uiContext,
+            {
+              requireExistingThread: false,
+              bootstrapHistory: messages,
+              deprecatedConversationHistory: messages,
+            },
+            onStatus,
+            onToken,
+          );
+        }
+      }
+
+      const requireExistingThread = messages.length > 0;
+      try {
+        return await apiClient.streamChat(
+          message,
+          threadId,
+          uiContext,
+          {
+            requireExistingThread,
+          },
+          onStatus,
+          onToken,
+        );
+      } catch (err) {
+        const code = (err as Error & { code?: string }).code;
+        if (code !== 'THREAD_NOT_FOUND') throw err;
+
+        // One-time bootstrap fallback from local persisted history.
+        console.warn('Thread missing on server, retrying with bootstrap history.');
+        return apiClient.streamChat(
+          message,
+          threadId,
+          uiContext,
+          {
+            requireExistingThread: false,
+            bootstrapHistory: messages,
+            deprecatedConversationHistory: messages,
+          },
+          onStatus,
+          onToken,
+        );
+      }
+    };
+
     try {
-      const response = isResumingFromInterrupt
-        ? await apiClient.streamResume(message, threadId, onStatus, onToken)
-        : await apiClient.streamChat(message, messages, threadId, onStatus, onToken);
+      const response = await sendWithBootstrapRetry();
 
       // Handle interrupted response (agent asking a clarifying question)
       if (response.interrupted) {
@@ -484,6 +625,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
           visualizations: response.visualizations,
           outOfScope: response.out_of_scope,
           apiRequests: response.api_requests,
+          actions: response.actions,
+          memoryStatus: response.memory_status,
         };
 
         if (idx >= 0) {
@@ -499,6 +642,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return get().messages.find(m => m.id === streamingMsgId) ?? null;
     } catch (err) {
       console.error('Chat error:', err);
+      const errCode = (err as Error & { code?: string }).code;
+      const isThreadMissing = errCode === 'THREAD_NOT_FOUND';
 
       set((state) => {
         const msgs = [
@@ -506,7 +651,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
           {
             id: generateMessageId(),
             role: 'assistant' as const,
-            content: 'Sorry, I encountered an error. Please make sure the backend is running.',
+            content: isThreadMissing
+              ? 'I lost server-side thread memory and could not restore this conversation. Please reset chat and try again.'
+              : 'Sorry, I encountered an error. Please make sure the backend is running.',
             timestamp: new Date(),
           },
         ];
@@ -584,6 +731,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   songViewMode: 'tab',
   highlightedNotes: [],
+  playheadMeasureIndex: 0,
+  selectedBeatId: null,
 
   searchSongs: async (query) => {
     set({ songSearchLoading: true, songSearchError: null, songSearchQuery: query });
@@ -609,6 +758,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       selectedTrackIndex: 0,
       songViewMode: 'tab',
       highlightedNotes: [],
+      playheadMeasureIndex: 0,
+      selectedBeatId: null,
     });
     try {
       const tracksData = await apiClient.getSongTracks(song.song_id);
@@ -633,9 +784,59 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
 
       const tabData = await apiClient.getTabData(song.song_id, trackIdx);
-      set({ tabData, selectedTrackIndex: trackIdx, tabLoading: false });
+      set({
+        tabData,
+        selectedTrackIndex: trackIdx,
+        tabLoading: false,
+        playheadMeasureIndex: 0,
+        selectedBeatId: null,
+      });
     } catch (err) {
       console.error('Failed to load song:', err);
+      set({
+        tabError: err instanceof Error ? err.message : 'Failed to load song',
+        tabLoading: false,
+      });
+    }
+  },
+
+  selectSongById: async (songId) => {
+    const state = get();
+    const fromResults = state.songSearchResults.find((s) => s.song_id === songId);
+    if (fromResults) {
+      await state.selectSong(fromResults);
+      return;
+    }
+
+    set({
+      tabLoading: true,
+      tabError: null,
+      tabData: null,
+      chordProData: null,
+      selectedTrackIndex: 0,
+      songViewMode: 'tab',
+      highlightedNotes: [],
+      playheadMeasureIndex: 0,
+      selectedBeatId: null,
+    });
+
+    try {
+      const tracksData = await apiClient.getSongTracks(songId);
+      const syntheticSong: SongSearchResult = {
+        song_id: songId,
+        artist: tracksData.artist,
+        title: tracksData.title,
+        has_chords: true,
+        tracks: tracksData.tracks,
+      };
+
+      set({ selectedSong: syntheticSong, songTracks: tracksData });
+
+      const defaultTrack = tracksData.tracks.find(t => !t.is_vocal && !t.is_empty);
+      const trackIdx = defaultTrack ? defaultTrack.index : 0;
+      await get().selectTrack(trackIdx);
+    } catch (err) {
+      console.error('Failed to load song by ID:', err);
       set({
         tabError: err instanceof Error ? err.message : 'Failed to load song',
         tabLoading: false,
@@ -646,7 +847,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
   selectTrack: async (index) => {
     const { selectedSong, songTracks, availableTunings } = get();
     if (!selectedSong) return;
-    set({ selectedTrackIndex: index, tabLoading: true, tabError: null, highlightedNotes: [] });
+    set({
+      selectedTrackIndex: index,
+      tabLoading: true,
+      tabError: null,
+      highlightedNotes: [],
+      playheadMeasureIndex: 0,
+      selectedBeatId: null,
+    });
 
     // Auto-detect tuning from new track
     const track = songTracks?.tracks.find(t => t.index === index);
@@ -664,7 +872,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     try {
       const tabData = await apiClient.getTabData(selectedSong.song_id, index);
-      set({ tabData, tabLoading: false });
+      set({
+        tabData,
+        tabLoading: false,
+        playheadMeasureIndex: 0,
+        selectedBeatId: null,
+      });
     } catch (err) {
       console.error('Failed to load track:', err);
       set({
@@ -686,6 +899,39 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   setSongViewMode: (mode) => set({ songViewMode: mode }),
   setHighlightedNotes: (notes) => set({ highlightedNotes: notes }),
+  setPlayheadMeasureIndex: (index) => set({ playheadMeasureIndex: index }),
+  setSelectedBeatId: (id) => set({ selectedBeatId: id }),
+  focusMeasureBeat: (measureIndex, beatIndex) => {
+    const { tabData } = get();
+    const measures = tabData?.tab_data?.measures ?? [];
+    if (measures.length === 0) {
+      set({ playheadMeasureIndex: 0, selectedBeatId: null, highlightedNotes: [] });
+      return;
+    }
+
+    const clampedMeasure = Math.max(0, Math.min(measures.length - 1, measureIndex));
+    const beats = getBeatsFromMeasure(measures[clampedMeasure]);
+    if (beats.length === 0) {
+      set({
+        playheadMeasureIndex: clampedMeasure,
+        selectedBeatId: null,
+        highlightedNotes: [],
+      });
+      return;
+    }
+
+    const fallbackBeatIndex = firstPlayableBeatIndex(beats);
+    const resolvedBeatIndex = Math.max(
+      0,
+      Math.min(beats.length - 1, beatIndex ?? fallbackBeatIndex ?? 0),
+    );
+    const beat = beats[resolvedBeatIndex];
+    set({
+      playheadMeasureIndex: clampedMeasure,
+      selectedBeatId: `${clampedMeasure}:${resolvedBeatIndex}`,
+      highlightedNotes: toHighlightedNotes(beat),
+    });
+  },
   clearHighlightedNotes: () => set({ highlightedNotes: [] }),
 
   clearSongState: () => set({
@@ -703,6 +949,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     chordProLoading: false,
     songViewMode: 'tab',
     highlightedNotes: [],
+    playheadMeasureIndex: 0,
+    selectedBeatId: null,
   }),
 
   backToSearch: () => set({
@@ -715,6 +963,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     chordProData: null,
     chordProLoading: false,
     highlightedNotes: [],
+    playheadMeasureIndex: 0,
+    selectedBeatId: null,
   }),
 }));
 
@@ -784,6 +1034,8 @@ export const useTabLoading = () => useAppStore((state) => state.tabLoading);
 export const useTabError = () => useAppStore((state) => state.tabError);
 export const useSongViewMode = () => useAppStore((state) => state.songViewMode);
 export const useHighlightedNotes = () => useAppStore((state) => state.highlightedNotes);
+export const usePlayheadMeasureIndex = () => useAppStore((state) => state.playheadMeasureIndex);
+export const useSelectedBeatId = () => useAppStore((state) => state.selectedBeatId);
 
 // Tuning selectors
 export const useSelectedTuning = () => useAppStore((state) => state.selectedTuning);

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -16,6 +16,9 @@ export interface ChatMessage {
   } | null;
   // Parsed API requests from backend
   apiRequests?: ApiRequests | null;
+  // New action/memory metadata
+  actions?: AgentAction[];
+  memoryStatus?: MemoryStatus;
 }
 
 // API request/response types (matches backend schemas)
@@ -24,9 +27,49 @@ export interface AgentMessageRequest {
   content: string;
 }
 
+export interface UiScaleContext {
+  root?: string | null;
+  mode?: string | null;
+}
+
+export interface UiChordContext {
+  root?: string | null;
+  quality?: string | null;
+}
+
+export interface UiSongContext {
+  song_id?: number | null;
+  artist?: string | null;
+  title?: string | null;
+  has_chords?: boolean | null;
+}
+
+export interface UiHighlightedNote {
+  string: number;
+  fret: number;
+}
+
+export interface UiContext {
+  app_mode?: 'scale' | 'chord' | 'song';
+  display_mode?: 'notes' | 'intervals';
+  selected_tuning?: string;
+  custom_tuning_notes?: string[] | null;
+  selected_scale?: UiScaleContext | null;
+  selected_chord?: UiChordContext | null;
+  selected_song?: UiSongContext | null;
+  selected_track_index?: number;
+  song_view_mode?: 'tab' | 'chords';
+  playhead_measure_index?: number;
+  selected_beat_id?: string | null;
+  highlighted_notes?: UiHighlightedNote[];
+}
+
 export interface AgentRequest {
   message: string;
-  conversation_history: AgentMessageRequest[];
+  conversation_history?: AgentMessageRequest[]; // Deprecated fallback
+  bootstrap_history?: AgentMessageRequest[];
+  require_existing_thread?: boolean;
+  ui_context?: UiContext;
   thread_id?: string;  // For conversation tracking and interrupts
 }
 
@@ -45,6 +88,49 @@ export interface ApiRequests {
   scale: ScaleApiRequest | null;
 }
 
+export type MemoryStatus = 'restored' | 'bootstrapped' | 'fresh';
+
+export type SongSearchAction = {
+  type: 'song.search';
+  query: string;
+};
+
+export type SongSelectAction = {
+  type: 'song.select';
+  song_id: number;
+};
+
+export type SongTrackSelectAction = {
+  type: 'song.track.select';
+  track_index: number;
+};
+
+export type SongMeasureFocusAction = {
+  type: 'song.measure.focus';
+  measure_index: number;
+  beat_index?: number;
+};
+
+export type TheoryShowChordAction = {
+  type: 'theory.show_chord';
+  root: string;
+  quality: string;
+};
+
+export type TheoryShowScaleAction = {
+  type: 'theory.show_scale';
+  root: string;
+  mode: string;
+};
+
+export type AgentAction =
+  | SongSearchAction
+  | SongSelectAction
+  | SongTrackSelectAction
+  | SongMeasureFocusAction
+  | TheoryShowChordAction
+  | TheoryShowScaleAction;
+
 export interface AgentResponse {
   answer: string;
   scale: string | null;
@@ -57,11 +143,14 @@ export interface AgentResponse {
     action?: string;
   } | null;
   api_requests?: ApiRequests;
+  actions?: AgentAction[];
+  memory_status?: MemoryStatus;
 }
 
 export interface ResumeRequest {
   response: string;  // User's answer to clarifying question
   thread_id: string;
+  ui_context?: UiContext;
 }
 
 // SSE wire-format event types (matches backend stream endpoints)
@@ -70,5 +159,5 @@ export type SseEvent =
   | { event: 'token';     data: { text: string } }
   | { event: 'interrupt'; data: { clarifying_question?: string; action?: string } }
   | { event: 'answer';    data: AgentResponse }
-  | { event: 'error';     data: { detail: string } }
+  | { event: 'error';     data: { detail: string; code?: string; thread_id?: string } }
   | { event: 'done';      data: Record<string, never> };

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -123,13 +123,29 @@ export type TheoryShowScaleAction = {
   mode: string;
 };
 
+export type FretboardHighlightPosition = {
+  string: number; // 1-6 (1 = high E)
+  fret: number;
+};
+
+export type FretboardHighlightGroup = {
+  name: string;
+  positions: FretboardHighlightPosition[];
+};
+
+export type FretboardHighlightAction = {
+  type: 'fretboard.highlight';
+  groups: FretboardHighlightGroup[];
+};
+
 export type AgentAction =
   | SongSearchAction
   | SongSelectAction
   | SongTrackSelectAction
   | SongMeasureFocusAction
   | TheoryShowChordAction
-  | TheoryShowScaleAction;
+  | TheoryShowScaleAction
+  | FretboardHighlightAction;
 
 export interface AgentResponse {
   answer: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,7 +107,10 @@ export interface ChordQualitiesResponse {
 }
 
 // App modes
-export type AppMode = 'scales' | 'chords';
+export type AppMode = 'scale' | 'chord' | 'song';
 
 // Display mode for notes
 export type DisplayMode = 'notes' | 'intervals';
+
+// Song types
+export * from './song';

--- a/frontend/src/types/song.ts
+++ b/frontend/src/types/song.ts
@@ -6,6 +6,7 @@ export interface TrackSummary {
   instrument: string;
   is_vocal: boolean;
   is_empty: boolean;
+  tuning: number[] | null;
 }
 
 export interface SongSearchResult {

--- a/frontend/src/types/song.ts
+++ b/frontend/src/types/song.ts
@@ -1,0 +1,100 @@
+// --- Song search ---
+
+export interface TrackSummary {
+  index: number;
+  name: string;
+  instrument: string;
+  is_vocal: boolean;
+  is_empty: boolean;
+}
+
+export interface SongSearchResult {
+  song_id: number;
+  artist: string;
+  title: string;
+  has_chords: boolean;
+  tracks: TrackSummary[];
+}
+
+export interface SongSearchResponse {
+  results: SongSearchResult[];
+}
+
+// --- Song tracks ---
+
+export interface SongTracksResponse {
+  song_id: number;
+  artist: string;
+  title: string;
+  tracks: TrackSummary[];
+}
+
+// --- Tab data ---
+
+export interface TabNote {
+  string: number;
+  fret: number;
+  rest?: boolean;
+  dead?: boolean;
+  ghost?: boolean;
+  slide?: boolean;
+  bend?: boolean;
+  hp?: boolean;
+  vibrato?: boolean;
+  harmonic?: boolean;
+  staccato?: boolean;
+  accentuated?: boolean;
+}
+
+export interface TabBeat {
+  notes: TabNote[];
+  chord?: { text: string };
+  pickStroke?: 'up' | 'down';
+  letRing?: boolean;
+  palmMute?: boolean;
+  downStroke?: boolean;
+  upStroke?: boolean;
+}
+
+export interface TabMeasure {
+  voices: Array<{ beats: TabBeat[] }>;
+  marker?: { text: string };
+  header?: {
+    timeSignature?: {
+      numerator?: number;
+      denominator?: number;
+    };
+  };
+}
+
+export interface TabData {
+  measures: TabMeasure[];
+  tuning?: number[];
+  name?: string;
+  automations?: { tempo?: Array<{ bpm: number }> };
+  newLyrics?: Array<{ text: string }>;
+}
+
+export interface TabDataResponse {
+  song_id: number;
+  artist: string;
+  title: string;
+  track_name: string;
+  tab_data: TabData;
+}
+
+// --- ChordPro ---
+
+export interface ChordProResponse {
+  song_id: number;
+  artist: string;
+  title: string;
+  chordpro: string;
+}
+
+// --- Highlighted notes for fretboard bridge ---
+
+export interface HighlightedNote {
+  string: number;
+  fret: number;
+}

--- a/frontend/src/utils/tuning.ts
+++ b/frontend/src/utils/tuning.ts
@@ -1,4 +1,4 @@
-const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const;
+const NOTE_NAMES = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'] as const;
 
 export function midiToNoteName(midi: number, includeOctave: boolean = false): string {
   if (!Number.isFinite(midi)) return '?';
@@ -38,8 +38,8 @@ export function matchTuningId(
   tunings: Array<{ id: string; notes: string[] }>,
 ): string | null {
   const noteToIndex = (n: string) => {
-    const flat: Record<string, string> = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' };
-    const normalized = flat[n] ?? n;
+    const sharp: Record<string, string> = { 'C#': 'Db', 'D#': 'Eb', 'F#': 'Gb', 'G#': 'Ab', 'A#': 'Bb' };
+    const normalized = sharp[n] ?? n;
     return NOTE_NAMES.indexOf(normalized as typeof NOTE_NAMES[number]);
   };
   const target = notes.map(noteToIndex);

--- a/frontend/src/utils/tuning.ts
+++ b/frontend/src/utils/tuning.ts
@@ -21,6 +21,37 @@ export function formatTuning(
   return ordered.map((midi) => midiToNoteName(midi, includeOctave)).join(' ');
 }
 
+/**
+ * Convert Songsterr MIDI tuning array to note names.
+ * Songsterr tuning is ordered high-to-low (string 1 to 6), same as app convention.
+ */
+export function midiTuningToNotes(midiTuning: number[]): string[] {
+  return midiTuning.map((midi) => midiToNoteName(midi));
+}
+
+/**
+ * Match a set of tuning notes against known tunings.
+ * Compares by note index to handle enharmonic equivalents (e.g. D# vs Eb).
+ */
+export function matchTuningId(
+  notes: string[],
+  tunings: Array<{ id: string; notes: string[] }>,
+): string | null {
+  const noteToIndex = (n: string) => {
+    const flat: Record<string, string> = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' };
+    const normalized = flat[n] ?? n;
+    return NOTE_NAMES.indexOf(normalized as typeof NOTE_NAMES[number]);
+  };
+  const target = notes.map(noteToIndex);
+  for (const t of tunings) {
+    const candidate = t.notes.map(noteToIndex);
+    if (candidate.length === target.length && candidate.every((v, i) => v === target[i])) {
+      return t.id;
+    }
+  }
+  return null;
+}
+
 export function pickPrimaryTuning(
   tunings: Array<number[] | null | undefined>,
   options: { includeOctave?: boolean; lowToHigh?: boolean } = {},

--- a/frontend/src/utils/tuning.ts
+++ b/frontend/src/utils/tuning.ts
@@ -1,0 +1,31 @@
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const;
+
+export function midiToNoteName(midi: number, includeOctave: boolean = false): string {
+  if (!Number.isFinite(midi)) return '?';
+  const noteIndex = ((Math.round(midi) % 12) + 12) % 12;
+  const note = NOTE_NAMES[noteIndex];
+  if (!includeOctave) return note;
+
+  const octave = Math.floor(Math.round(midi) / 12) - 1;
+  return `${note}${octave}`;
+}
+
+export function formatTuning(
+  tuning: number[] | null | undefined,
+  options: { includeOctave?: boolean; lowToHigh?: boolean } = {},
+): string | null {
+  if (!tuning || tuning.length === 0) return null;
+
+  const { includeOctave = false, lowToHigh = true } = options;
+  const ordered = lowToHigh ? [...tuning].reverse() : [...tuning];
+  return ordered.map((midi) => midiToNoteName(midi, includeOctave)).join(' ');
+}
+
+export function pickPrimaryTuning(
+  tunings: Array<number[] | null | undefined>,
+  options: { includeOctave?: boolean; lowToHigh?: boolean } = {},
+): string | null {
+  const first = tunings.find((tuning) => tuning && tuning.length > 0);
+  if (!first) return null;
+  return formatTuning(first, options);
+}


### PR DESCRIPTION
Song view — Search songs via Songsterr, browse tracks, and view tablature in a scrollable measure-by-measure tab viewer. Selecting a beat highlights notes on the fretboard. Includes ChordPro (lyrics + chords) view, tuning auto-detection from tracks, and keyboard navigation between beats/measures.
Agent upgrades — Simplified the LangGraph graph to a three-node architecture (gate → interrupt → answer). The agent can now search for songs, navigate to measures, emit fretboard highlight groups, and trigger UI actions. Added conversation summarization, UI context awareness, and checkpointed threads (in-memory or SQLite).
Service layer refactor — Extracted business logic from routers into services/ (scale, chord, fretboard, songsterr). Routers are now thin validation + delegation layers. Services are reusable by both HTTP endpoints and the agent.
Tuning support — Alternate tunings (Drop D, Open G, DADGAD, etc.) across the full stack. Custom tuning notes from song tracks are resolved to known tunings when possible.
README — Updated to document the song feature, agent architecture, service layer, and new API endpoints.