### PR TITLE
Feature/agent cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ The backend exposes a few endpoints — full docs available at `/docs` when the 
 The AI tutor is a LangGraph state graph with three nodes:
 
 ```
-START -> prepare_question -> clarify_input -> generate_answer -> END
+START -> classify_input -> clarify_input -> generate_answer -> END
 ```
 
-1. **prepare_question** — Gate node. Classifies the user's message as proceed, needs-clarification, or out-of-scope. Uses a running conversation summary and UI context (selected scale/chord/song, playhead position) to make the decision.
+1. **classify_input** — Gate node. Classifies the user's message as proceed, needs-clarification, or out-of-scope. Uses a running conversation summary and UI context (selected scale/chord/song, playhead position) to make the decision.
 2. **clarify_input** — If the gate requested clarification, this node interrupts the graph (LangGraph `interrupt`) and returns the question to the user. When the user responds, the graph resumes and routes to `generate_answer`.
 3. **generate_answer** — Multi-step answer generation:
    - **Song tool planning** — An LLM call decides whether to search for a song or navigate to a measure, producing action payloads the frontend executes.
@@ -115,7 +115,7 @@ The agent supports both synchronous and SSE streaming endpoints. Conversation st
 │   │   ├── routers/          # Thin FastAPI route handlers
 │   │   ├── services/         # Business logic (scale, chord, fretboard, songsterr)
 │   │   ├── music/            # Pure music theory engine (scales, chords, tunings, notes)
-│   │   ├── agent/            # LangGraph AI tutor (graph, parser)
+│   │   ├── agent/            # LangGraph AI tutor (graph, nodes, prompts, parser)
 │   │   └── models/           # Pydantic schemas
 │   └── requirements.txt
 │

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -2,7 +2,7 @@
 Guitar Tutor LangGraph Agent.
 
 Graph nodes:
-1. prepare_question - normalizes and validates the user's question
+1. classify_input - classifies whether to proceed, clarify, or reject the user's question
 2. clarify_input - handles interrupt/resume for clarifying questions
 3. generate_answer - generates answer text + structured metadata/actions
 """
@@ -10,22 +10,33 @@ Graph nodes:
 import logging
 import os
 import re
-from typing import Any, Generator, List, Optional, TypedDict
+from typing import Any, Generator, List, Optional
 
 from dotenv import load_dotenv
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command, interrupt
-from pydantic import BaseModel, Field
 
 from app.agent.parser import parse_chord_name, parse_scale_name
+from app.agent.prompts import (
+    ANSWER_POSTPROCESS_INSTRUCTIONS,
+    ANSWER_TEXT_INSTRUCTIONS,
+    CLASSIFY_INPUT_INSTRUCTIONS,
+    SONG_TOOL_INTENT_INSTRUCTIONS,
+    SUMMARY_INSTRUCTIONS,
+)
+from app.agent.schemas import (
+    AnswerPostProcessSchema,
+    ClassificationSchema,
+    OverallState,
+    SongToolPlanSchema,
+)
+from app.agent.song_tools import execute_song_search, resolve_measure_focus
 from app.config import get_settings
-from app.models.songsterr import SongsterrRecord
 from app.music.notes import get_note_at_fret
 from app.music.tunings import get_tuning_notes
-from app.services import songsterr
 
 load_dotenv()
 
@@ -40,203 +51,10 @@ class ThreadNotFoundError(RuntimeError):
         self.thread_id = thread_id
 
 
-# --- Structured output schemas ---
-
-class PreppedQuestionSchema(TypedDict):
-    """Schema for the prepare_question node output."""
-
-    out_of_scope: bool = Field(False, description="Whether the question is out of scope")
-    clarifying_question_for_user: Optional[str] = Field(None, description="A clarifying question to send to the user")
-
-
-class SongToolPlanSchema(BaseModel):
-    """Structured song-tool intent chosen during answer generation."""
-
-    song_search_query: Optional[str] = Field(
-        None,
-        description=(
-            "Search query for a specific song the user wants opened in the song UI, "
-            "for example 'frisky dominic fike'. Null when no song lookup is needed."
-        ),
-    )
-    focus_measure_number: Optional[int] = Field(
-        None,
-        description=(
-            "1-based measure number the user wants focused in the currently selected or requested song. "
-            "Null when no measure navigation is needed."
-        ),
-    )
-
-
-class FretboardHighlightPositionSchema(TypedDict):
-    string: int
-    fret: int
-
-
-class FretboardHighlightGroupSchema(TypedDict):
-    name: str
-    positions: List[FretboardHighlightPositionSchema]
-
-
-class AnswerPostProcessSchema(TypedDict):
-    """Combined schema for metadata extraction + fretboard highlights in one call."""
-
-    scale: Optional[str] = Field(None, description="Most relevant scale name")
-    chord_choices: List[str] = Field(default_factory=list, description="List of chord names recommended")
-    visualizations: bool = Field(False, description="Whether visualizations are needed")
-    highlight_groups: List[FretboardHighlightGroupSchema] = Field(default_factory=list, description="Fretboard highlight groups")
-
-
-class OverallState(MessagesState):
-    """Overall state for the agent graph."""
-
-    clarifying_question_for_user: Optional[str] = None
-    answer: str = ""
-    scale: Optional[str] = None
-    chord_choices: List[str] = []
-    visualizations: bool = False
-    out_of_scope: bool = False
-
-    # New context/memory fields
-    ui_context: dict = {}
-    running_summary: str = ""
-    summary_turn_count: int = 0
-
-    # New response fields
-    actions: List[dict] = []
-    memory_status: str = "fresh"
-
-
-# --- Prompt templates ---
-
-PREP_QUESTION_INSTRUCTIONS = """You are the Guitar Tutor gate. Decide whether to proceed, clarify, or reject the user's question. Do NOT answer the question yourself.
-
-Inputs:
-- running_summary: {running_summary}
-- previous_context: {previous_context}
-- ui_context: {ui_context}
-- user_question: {user_question}
-
-Return JSON ONLY. Produce exactly one of these shapes:
-1) Proceed (preferred)
-{{"out_of_scope": false}}
-
-2) Need clarification
-{{"clarifying_question_for_user": "<one short clarifying question>", "out_of_scope": false}}
-
-3) Out of scope
-{{"out_of_scope": true}}
-
-Guidelines:
-- Default to proceeding. Trust the answer model's judgement to handle ambiguity, fill in gaps, and make creative choices.
-- Never clarify about format, notation style, or level of detail — just proceed.
-- Never clarify to confirm intent — if the user mentions a song, artist, chord, scale, or technique, proceed.
-- Only clarify when the question is genuinely unanswerable without more info (e.g. "help me with this" with zero context).
-- For a pure greeting with no music content, use clarifying_question_for_user to greet briefly and ask what guitar/music help they want.
-- If the request is not about music, guitar, songs, tabs, measures, or music theory, return out_of_scope true.
-"""
-
-SONG_TOOL_INTENT_INSTRUCTIONS = """You are deciding whether the Guitar Tutor should use song UI tools before answering. Do NOT answer the user.
-
-Inputs:
-- running_summary: {running_summary}
-- previous_context: {previous_context}
-- ui_context: {ui_context}
-- user_question: {user_question}
-
-Return JSON ONLY with this exact shape:
-{{
-  "song_search_query": string | null,
-  "focus_measure_number": integer | null
-}}
-
-Rules:
-- Use "song_search_query" when the user wants to open, load, search, show, display, or learn a specific song/tab in the Songs UI.
-- Natural teaching phrasing still counts as song intent. Example: "show me how to play wonderwall" should return {{"song_search_query": "wonderwall", "focus_measure_number": null}}.
-- Include artist names when they are present or clearly implied. Example: "teach me frisky by dominic fike" -> "frisky dominic fike".
-- Do NOT set song_search_query for theory-only requests like chords, scales, intervals, fretboard notes, or generic techniques.
-- Use "focus_measure_number" only when the user explicitly asks to jump to, show, start at, or focus a numbered measure in a song.
-- Measure numbers are 1-based in your output.
-- If no song tool is needed, return null for both fields.
-"""
-
-ANSWER_TEXT_INSTRUCTIONS = """You are the Guitar Tutor. Answer the user's guitar/music theory question.
-
-Hard constraints:
-- ONLY answer music theory, guitar, songs, tabs, and measure-navigation related questions.
-- Keep output concise: 1-3 paragraphs.
-
-Inputs:
-- Running summary: {running_summary}
-- UI context: {ui_context}
-- Tool context: {tool_context}
-
-Behavior:
-- Be clear and pedagogical. Explain WHY choices work.
-- The user's explicit intent always takes priority over the current UI state.
-- Use ui_context for current selection/playhead/highlighted notes only when the user references "this"/"current" context.
-- If a song/tool lookup succeeded, ground your answer in those results.
-- Do NOT say you lack direct tab database access. You are integrated with a song-tab lookup tool.
-"""
-
-ANSWER_POSTPROCESS_INSTRUCTIONS = """Given a guitar/music question and answer, extract structured metadata AND fretboard highlight positions in a single response.
-
-Question: {user_question}
-Answer: {answer}
-UI context: {ui_context}
-Tuning (string 1=high E to string 6=low E): {tuning_notes}
-
---- PART 1: Metadata ---
-Extract:
-- scale: the single most relevant scale name (e.g., "A minor pentatonic"), or null
-- chord_choices: list of chord names mentioned or recommended (e.g., ["C", "Am", "F", "G"])
-- visualizations: true if the answer involves chords, scales, progressions, song tabs, or measure navigation
-
---- PART 2: Fretboard highlights ---
-Extract highlight_groups: fret positions to highlight on the interactive fretboard.
-
-When to emit groups:
-- Emit groups when the answer discusses SPECIFIC fret positions, voicings, shapes, or fingerings. This includes:
-  - Explicit string/fret references (e.g. "3rd fret on the A string")
-  - Tab-notation voicings (e.g. "x32010", "3x2003") — convert these to string/fret positions (leftmost digit = string 6/low E, rightmost = string 1/high E; "x" = muted/skip, "0" = open)
-  - Named shapes with positions (e.g. "CAGED shape at fret 5", "barre chord at 7th fret")
-- Do NOT emit groups for general theory, chord names without ANY position info, or scale names without specific fret references.
-
-Group rules:
-- Each group is one named shape/voicing/position set. Multiple groups = multiple alternatives to cycle through.
-- String numbering: string 1 = high E (thinnest), string 6 = low E (thickest). Fret 0 = open string.
-- Keep group names short (2-5 words), e.g. "Open E", "Barre at 5th", "Box 1", "CAGED A shape".
-- Omit muted/unplayed strings — only include strings that are actually fretted or open and part of the shape.
-- Max 6 groups. Max 6 positions per group.
-
-Playability constraints (CRITICAL — every voicing MUST be physically playable):
-- Max 4-fret span between the lowest and highest fretted notes (excluding open strings). Stretch up to 5 frets ONLY for intentionally creative/extended voicings.
-- At most one note per string.
-- All fretted notes must be reachable simultaneously by a human fretting hand — no impossible finger stretches.
-- Prefer standard voicing positions (open chords, common barre shapes, CAGED forms) unless the user specifically asks for unusual or creative voicings.
-- When suggesting chord progressions, use voicings in nearby positions to minimize hand movement between chords.
-
-Return empty list if no specific fret positions apply.
-"""
-
-SUMMARY_INSTRUCTIONS = """Summarize the conversation for future guitar tutoring context.
-
-Current running summary:
-{running_summary}
-
-Older raw messages to compress:
-{older_messages}
-
-Return a concise summary under 180 words capturing:
-- User goals/preferences
-- Musical key/tuning/song context
-- Prior recommendations and constraints
-"""
-
 # Node names for status tracking
 _NODE_FIELDS = {
     "answer": "generate_answer",
-    "clarifying_question_for_user": "prepare_question",
+    "clarifying_question_for_user": "classify_input",
 }
 
 
@@ -302,19 +120,19 @@ class GuitarTutorAgent:
     def _build_graph(self) -> StateGraph:
         builder = StateGraph(OverallState)
 
-        builder.add_node("prepare_question", self._prepare_question)
+        builder.add_node("classify_input", self._classify_input)
         builder.add_node("clarify_input", self._clarify_input)
         builder.add_node("generate_answer", self._generate_answer)
 
-        builder.add_edge(START, "prepare_question")
-        builder.add_edge("prepare_question", "clarify_input")
+        builder.add_edge(START, "classify_input")
+        builder.add_edge("classify_input", "clarify_input")
         builder.add_edge("generate_answer", END)
 
         return builder.compile(checkpointer=self.memory)
 
     # --- Graph nodes ---
 
-    def _prepare_question(self, state: dict) -> dict:
+    def _classify_input(self, state: dict) -> dict:
         messages = state.get("messages", [])
         ui_context = state.get("ui_context") or {}
         prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
@@ -336,7 +154,7 @@ class GuitarTutorAgent:
             }
 
         system_message = SystemMessage(
-            content=PREP_QUESTION_INSTRUCTIONS.format(
+            content=CLASSIFY_INPUT_INSTRUCTIONS.format(
                 running_summary=running_summary or "None",
                 previous_context=previous_context,
                 ui_context=prompt_ui_context or "None",
@@ -345,7 +163,7 @@ class GuitarTutorAgent:
         )
 
         q = self._invoke_structured(
-            PreppedQuestionSchema,
+            ClassificationSchema,
             [system_message],
             fallback={"out_of_scope": False},
         )
@@ -423,14 +241,14 @@ class GuitarTutorAgent:
         messages = state.get("messages", [])
         user_question = self._message_text(messages[-1]) if messages else ""
         prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
-        song_tool_plan = self._plan_song_tools(
+        song_tool_plan = self._plan_song_intent(
             user_question=user_question,
             messages=messages,
             ui_context=ui_context,
             running_summary=running_summary,
         )
         logger.info("Song tool plan=%s", song_tool_plan)
-        tool_context, song_actions = self._run_song_tools(
+        tool_context, song_actions = self._execute_song_actions(
             user_question,
             ui_context,
             song_search_query=song_tool_plan.get("song_search_query"),
@@ -695,7 +513,7 @@ class GuitarTutorAgent:
                 valid_groups.append({"name": name, "positions": positions})
         return valid_groups
 
-    def _plan_song_tools(
+    def _plan_song_intent(
         self,
         *,
         user_question: str,
@@ -786,7 +604,7 @@ class GuitarTutorAgent:
             deduped.append(action)
         return deduped
 
-    def _run_song_tools(
+    def _execute_song_actions(
         self,
         question_text: str,
         ui_context: dict,
@@ -798,8 +616,7 @@ class GuitarTutorAgent:
         if not self.tool_calling_enabled:
             return "", []
 
-        q = question_text.strip()
-        lower_q = q.lower()
+        lower_q = question_text.strip().lower()
         search_query = song_search_query.strip() if isinstance(song_search_query, str) else None
         if search_query and search_query.lower() in {"null", "none"}:
             search_query = None
@@ -811,37 +628,19 @@ class GuitarTutorAgent:
         selected_song_id = selected_song.get("song_id")
         selected_track_index = int((ui_context or {}).get("selected_track_index") or 0)
 
-        # 1) Optional explicit search intent
+        # 1) Song search
         if search_query:
-            try:
-                records = songsterr.search_songs_sync(search_query)
-                if records:
-                    actions.append({"type": "song.search", "query": search_query})
-                    best, score = self._choose_best_song_match(records, search_query)
-                    if best and score >= 55:
-                        actions.append({"type": "song.select", "song_id": best.song_id})
-                        actions.append({"type": "song.track.select", "track_index": 0})
-                        selected_song_id = best.song_id
-                        selected_track_index = 0
-                        tool_context_lines.append(
-                            f"Song search '{search_query}' matched: {best.artist} - {best.title} "
-                            f"(song_id={best.song_id}, score={score})."
-                        )
-                    else:
-                        tool_context_lines.append(
-                            f"Song search '{search_query}' returned results but no confident auto-select "
-                            f"(best score={score})."
-                        )
-                else:
-                    tool_context_lines.append(f"Song search '{search_query}' returned no results.")
-            except Exception as exc:
-                tool_context_lines.append(f"Song search failed for '{search_query}': {exc}")
+            ctx, acts, new_song_id, new_track = execute_song_search(search_query)
+            tool_context_lines.extend(ctx)
+            actions.extend(acts)
+            if new_song_id is not None:
+                selected_song_id = new_song_id
+                selected_track_index = new_track
 
-        # 2) Measure focus intent (for this song or selected search result)
+        # 2) Measure focus
         focus_measure_index = focus_measure_number - 1 if isinstance(focus_measure_number, int) else None
 
-        # For deictic identification questions ("what chord is this"), trust selected UI beat context
-        # and avoid expensive network measure resolution.
+        # For deictic identification questions, trust UI beat context instead.
         if self._is_context_identification_question(lower_q):
             selected_beat = (ui_context or {}).get("selected_beat_id")
             highlighted = (ui_context or {}).get("highlighted_notes") or []
@@ -852,28 +651,13 @@ class GuitarTutorAgent:
             focus_measure_index = None
 
         if focus_measure_index is not None and selected_song_id is not None:
-            try:
-                resolved_measure, resolved_beat = songsterr.resolve_measure_focus_sync(
-                    song_id=int(selected_song_id),
-                    track_index=selected_track_index,
-                    requested_measure_index=max(0, focus_measure_index),
-                )
-                action: dict[str, Any] = {
-                    "type": "song.measure.focus",
-                    "measure_index": resolved_measure,
-                }
-                if resolved_beat is not None:
-                    action["beat_index"] = resolved_beat
-                actions.append(action)
-                tool_context_lines.append(
-                    f"Resolved measure focus for song_id={selected_song_id}, track={selected_track_index}: "
-                    f"measure_index={resolved_measure}, beat_index={resolved_beat}."
-                )
-            except Exception as exc:
-                tool_context_lines.append(
-                    f"Could not resolve measure focus for song_id={selected_song_id}, "
-                    f"track={selected_track_index}: {exc}"
-                )
+            ctx, acts = resolve_measure_focus(
+                song_id=int(selected_song_id),
+                track_index=selected_track_index,
+                focus_measure_index=focus_measure_index,
+            )
+            tool_context_lines.extend(ctx)
+            actions.extend(acts)
         elif focus_measure_index is not None:
             tool_context_lines.append(
                 f"User asked to focus measure {focus_measure_number}, but no song is currently selected."
@@ -929,67 +713,6 @@ class GuitarTutorAgent:
             projected["highlighted_notes"] = resolved
 
         return projected
-
-    @staticmethod
-    def _normalize_search_text(text: str) -> str:
-        lowered = text.lower().strip()
-        lowered = re.sub(r"[^a-z0-9\s]", " ", lowered)
-        lowered = re.sub(r"\s+", " ", lowered).strip()
-        return lowered
-
-    def _split_query_title_artist(self, query: str) -> tuple[str, str]:
-        cleaned = self._normalize_search_text(query)
-        if " by " in cleaned:
-            title, artist = cleaned.split(" by ", 1)
-            return title.strip(), artist.strip()
-        return cleaned, ""
-
-    def _score_song_match(self, record: SongsterrRecord, query: str) -> int:
-        query_norm = self._normalize_search_text(query)
-        title_norm = self._normalize_search_text(record.title)
-        artist_norm = self._normalize_search_text(record.artist)
-        combined = f"{title_norm} {artist_norm}".strip()
-        q_title, q_artist = self._split_query_title_artist(query)
-
-        score = 0
-
-        # Strong exact/near-exact signals first.
-        if query_norm == combined:
-            score += 120
-        if q_title and q_title == title_norm:
-            score += 90
-        if q_artist and q_artist == artist_norm:
-            score += 80
-        if q_title and title_norm.startswith(q_title):
-            score += 40
-        if q_artist and artist_norm.startswith(q_artist):
-            score += 35
-
-        # Token overlap fallback.
-        q_tokens = set(query_norm.split())
-        c_tokens = set(combined.split())
-        if q_tokens and c_tokens:
-            overlap = len(q_tokens & c_tokens)
-            score += overlap * 8
-            # Penalize extra unrelated tokens for close-title collisions.
-            score -= max(0, len(c_tokens - q_tokens)) * 2
-
-        # Small boost for exact title even if artist differs slightly.
-        if q_title and title_norm == q_title:
-            score += 15
-
-        return score
-
-    def _choose_best_song_match(
-        self, records: List[SongsterrRecord], query: str
-    ) -> tuple[Optional[SongsterrRecord], int]:
-        if not records:
-            return None, 0
-
-        scored = [(record, self._score_song_match(record, query)) for record in records[:25]]
-        scored.sort(key=lambda x: x[1], reverse=True)
-        best_record, best_score = scored[0]
-        return best_record, best_score
 
     @staticmethod
     def _is_context_identification_question(lower_question: str) -> bool:

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -209,6 +209,8 @@ class GuitarTutorAgent:
 
     @staticmethod
     def _coerce_text(content: Any) -> str:
+        """Normalize LLM response content to a plain string.
+        Some models return content as a list of dicts (e.g. [{\"text\": \"...\"}])."""
         if isinstance(content, str):
             return content
         if isinstance(content, list):
@@ -267,6 +269,13 @@ class GuitarTutorAgent:
         ui_context: Optional[dict],
         thread_id: str,
     ) -> tuple[dict, str]:
+        """Build the initial state dict for a graph invocation.
+
+        Handles three cases:
+        - restored: thread already in checkpointer, just send the new message
+        - bootstrapped: new thread seeded with frontend conversation history
+        - fresh: brand new thread with no prior context
+        """
         if thread_exists:
             memory_status = "restored"
             messages = [HumanMessage(content=message)]
@@ -410,6 +419,8 @@ class GuitarTutorAgent:
         in_answer_node = False
         answer_tokens_started = False
 
+        # Dual stream: "messages" gives per-token chunks for SSE streaming,
+        # "values" gives full state snapshots after each node completes.
         for mode, event in self.graph.stream(
             graph_input,
             config=config,
@@ -419,7 +430,8 @@ class GuitarTutorAgent:
                 chunk, metadata = event
                 node = metadata.get("langgraph_node", "")
                 has_content = chunk.content and not getattr(chunk, "tool_call_chunks", None)
-                # Only yield tokens from generate_answer, and skip JSON-like chunks.
+                # Only yield tokens from generate_answer, and skip JSON-like chunks
+                # (structured output calls emit JSON that shouldn't reach the client).
                 if node == "generate_answer" and in_answer_node and has_content:
                     text = self._coerce_text(chunk.content)
                     if not answer_tokens_started:

--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -1,10 +1,8 @@
 """
 Guitar Tutor LangGraph Agent.
 
-Graph nodes:
-1. classify_input - classifies whether to proceed, clarify, or reject the user's question
-2. clarify_input - handles interrupt/resume for clarifying questions
-3. generate_answer - generates answer text + structured metadata/actions
+Graph construction, public API, and shared LLM utilities.
+Graph node implementations live in app.agent.nodes.
 """
 
 import logging
@@ -13,30 +11,24 @@ import re
 from typing import Any, Generator, List, Optional
 
 from dotenv import load_dotenv
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Command, interrupt
+from langgraph.types import Command
 
-from app.agent.parser import parse_chord_name, parse_scale_name
-from app.agent.prompts import (
-    ANSWER_POSTPROCESS_INSTRUCTIONS,
-    ANSWER_TEXT_INSTRUCTIONS,
-    CLASSIFY_INPUT_INSTRUCTIONS,
-    SONG_TOOL_INTENT_INSTRUCTIONS,
-    SUMMARY_INSTRUCTIONS,
+from app.agent.nodes import (
+    _build_theory_actions,
+    _classify_input,
+    _clarify_input,
+    _execute_song_actions,
+    _generate_answer,
+    _plan_song_intent,
+    _update_running_summary,
+    _validate_highlight_groups,
 )
-from app.agent.schemas import (
-    AnswerPostProcessSchema,
-    ClassificationSchema,
-    OverallState,
-    SongToolPlanSchema,
-)
-from app.agent.song_tools import execute_song_search, resolve_measure_focus
+from app.agent.schemas import OverallState
 from app.config import get_settings
-from app.music.notes import get_note_at_fret
-from app.music.tunings import get_tuning_notes
 
 load_dotenv()
 
@@ -60,6 +52,17 @@ _NODE_FIELDS = {
 
 class GuitarTutorAgent:
     """Guitar Tutor Agent using LangGraph."""
+
+    # Graph node methods — defined as standalone functions in nodes.py,
+    # assigned here so Python binds `self` automatically when called as methods.
+    _classify_input = _classify_input
+    _clarify_input = _clarify_input
+    _generate_answer = _generate_answer
+    _plan_song_intent = _plan_song_intent
+    _execute_song_actions = _execute_song_actions
+    _build_theory_actions = staticmethod(_build_theory_actions)
+    _validate_highlight_groups = staticmethod(_validate_highlight_groups)
+    _update_running_summary = _update_running_summary
 
     def __init__(
         self,
@@ -129,189 +132,6 @@ class GuitarTutorAgent:
         builder.add_edge("generate_answer", END)
 
         return builder.compile(checkpointer=self.memory)
-
-    # --- Graph nodes ---
-
-    def _classify_input(self, state: dict) -> dict:
-        messages = state.get("messages", [])
-        ui_context = state.get("ui_context") or {}
-        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
-
-        running_summary, summary_turn_count = self._maybe_refresh_summary(state)
-
-        recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
-        previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
-        last_question_text = self._message_text(messages[-1]) if messages else ""
-        lower_question = last_question_text.lower().strip()
-
-        # Deterministic fast-path: deictic chord-identification with strong UI context
-        if self._is_context_identification_question(lower_question) and self._has_strong_ui_context(ui_context):
-            return {
-                "clarifying_question_for_user": None,
-                "out_of_scope": False,
-                "running_summary": running_summary,
-                "summary_turn_count": summary_turn_count,
-            }
-
-        system_message = SystemMessage(
-            content=CLASSIFY_INPUT_INSTRUCTIONS.format(
-                running_summary=running_summary or "None",
-                previous_context=previous_context,
-                ui_context=prompt_ui_context or "None",
-                user_question=last_question_text,
-            )
-        )
-
-        q = self._invoke_structured(
-            ClassificationSchema,
-            [system_message],
-            fallback={"out_of_scope": False},
-        )
-
-        logger.info("Prepared question=%s", q)
-
-        clarifying_question_for_user = q.get("clarifying_question_for_user")
-        if isinstance(clarifying_question_for_user, str) and clarifying_question_for_user.strip().lower() in {"null", "none"}:
-            clarifying_question_for_user = None
-
-        return {
-            "clarifying_question_for_user": clarifying_question_for_user,
-            "out_of_scope": q.get("out_of_scope", False),
-            "running_summary": running_summary,
-            "summary_turn_count": summary_turn_count,
-        }
-
-    def _clarify_input(self, state: dict) -> Command:
-        clarifying_question_for_user = state.get("clarifying_question_for_user")
-
-        if not clarifying_question_for_user:
-            return Command(goto="generate_answer")
-
-        human_input = interrupt(
-            {
-                "clarifying_question": clarifying_question_for_user,
-                "action": "Please answer this question to continue",
-            }
-        )
-
-        return Command(
-            update={
-                "messages": [HumanMessage(content=human_input.get("response", ""))],
-                "clarifying_question_for_user": None,
-                "out_of_scope": False,
-            },
-            goto="generate_answer",
-        )
-
-    def _generate_answer(self, state: dict) -> dict:
-        clarifying_question_for_user = state.get("clarifying_question_for_user")
-        out_of_scope = state.get("out_of_scope", False)
-        running_summary = state.get("running_summary", "")
-        ui_context = state.get("ui_context") or {}
-        memory_status = state.get("memory_status", "fresh")
-
-        if out_of_scope:
-            refusal_msg = (
-                "I only help with guitar, songs/tabs, measures, and music theory. "
-                "Ask about chords, scales, fretboard shapes, progressions, songs, or tab sections."
-            )
-            return {
-                "messages": [AIMessage(content=refusal_msg)],
-                "answer": refusal_msg,
-                "scale": None,
-                "chord_choices": [],
-                "visualizations": False,
-                "out_of_scope": True,
-                "actions": [],
-                "memory_status": memory_status,
-            }
-
-        if clarifying_question_for_user:
-            return {
-                "messages": [AIMessage(content=clarifying_question_for_user)],
-                "answer": clarifying_question_for_user,
-                "scale": None,
-                "chord_choices": [],
-                "visualizations": False,
-                "out_of_scope": False,
-                "actions": [],
-                "memory_status": memory_status,
-            }
-
-        messages = state.get("messages", [])
-        user_question = self._message_text(messages[-1]) if messages else ""
-        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
-        song_tool_plan = self._plan_song_intent(
-            user_question=user_question,
-            messages=messages,
-            ui_context=ui_context,
-            running_summary=running_summary,
-        )
-        logger.info("Song tool plan=%s", song_tool_plan)
-        tool_context, song_actions = self._execute_song_actions(
-            user_question,
-            ui_context,
-            song_search_query=song_tool_plan.get("song_search_query"),
-            focus_measure_number=song_tool_plan.get("focus_measure_number"),
-        )
-
-        # Call 1: Generate answer text (regular LLM — streamed via stream_mode="messages")
-        text_system = SystemMessage(
-            content=ANSWER_TEXT_INSTRUCTIONS.format(
-                running_summary=running_summary or "None",
-                ui_context=prompt_ui_context or "None",
-                tool_context=tool_context or "None",
-            )
-        )
-
-        # Include recent conversation history so the LLM can resolve
-        # follow-up references ("this", "those chords", "show me visualizations for that")
-        recent_history = messages[-(self.recent_turn_window * 2):]
-        llm_messages = [text_system] + recent_history
-        response = self.llm.invoke(llm_messages)
-        answer_text = self._clean_answer_text(self._coerce_text(response.content))
-
-        # Call 2: Extract metadata + fretboard highlights in one structured call
-        tuning_id = ui_context.get("selected_tuning") or "standard"
-        custom_notes = ui_context.get("custom_tuning_notes")
-        tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
-
-        postprocess_system = SystemMessage(
-            content=ANSWER_POSTPROCESS_INSTRUCTIONS.format(
-                user_question=user_question,
-                answer=answer_text,
-                ui_context=prompt_ui_context or "None",
-                tuning_notes=tuning_notes,
-            )
-        )
-        post = self._invoke_structured(
-            AnswerPostProcessSchema,
-            [postprocess_system],
-            fallback={"scale": None, "chord_choices": [], "visualizations": False, "highlight_groups": []},
-        )
-
-        actions: list[dict] = []
-        if self.actions_enabled:
-            actions.extend(song_actions)
-            actions.extend(self._build_theory_actions(post.get("scale"), post.get("chord_choices", [])))
-
-            # Validate and add highlight groups from the combined call
-            highlight_groups = self._validate_highlight_groups(post.get("highlight_groups", []))
-            if highlight_groups:
-                actions.append({"type": "fretboard.highlight", "groups": highlight_groups})
-
-            actions = self._dedupe_actions(actions)
-
-        return {
-            "messages": [AIMessage(content=answer_text)],
-            "answer": answer_text,
-            "scale": post.get("scale"),
-            "chord_choices": post.get("chord_choices", []),
-            "visualizations": post.get("visualizations", False),
-            "out_of_scope": False,
-            "actions": actions,
-            "memory_status": memory_status,
-        }
 
     # --- Shared helpers ---
 
@@ -499,100 +319,6 @@ class GuitarTutorAgent:
         return "processing"
 
     @staticmethod
-    def _validate_highlight_groups(groups: list) -> list[dict]:
-        """Validate and filter highlight groups from structured output."""
-        valid_groups = []
-        for g in (groups or []):
-            name = g.get("name", "").strip()
-            positions = [
-                p for p in (g.get("positions") or [])
-                if isinstance(p.get("string"), int) and isinstance(p.get("fret"), int)
-                and 1 <= p["string"] <= 6 and 0 <= p["fret"] <= 22
-            ]
-            if name and positions:
-                valid_groups.append({"name": name, "positions": positions})
-        return valid_groups
-
-    def _plan_song_intent(
-        self,
-        *,
-        user_question: str,
-        messages: list,
-        ui_context: dict,
-        running_summary: str,
-    ) -> dict:
-        """Use the answer-phase model to decide if song tools are needed."""
-        prompt_ui_context = self._project_ui_context_for_prompt(ui_context)
-        recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
-        previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
-
-        system_message = SystemMessage(
-            content=SONG_TOOL_INTENT_INSTRUCTIONS.format(
-                running_summary=running_summary or "None",
-                previous_context=previous_context,
-                ui_context=prompt_ui_context or "None",
-                user_question=user_question,
-            )
-        )
-
-        plan = self._invoke_structured(
-            SongToolPlanSchema,
-            [system_message],
-            fallback={"song_search_query": None, "focus_measure_number": None},
-        )
-
-        song_search_query = plan.get("song_search_query")
-        if isinstance(song_search_query, str):
-            song_search_query = song_search_query.strip()
-            if song_search_query.lower() in {"", "null", "none"}:
-                song_search_query = None
-        else:
-            song_search_query = None
-
-        focus_measure_number = plan.get("focus_measure_number")
-        try:
-            focus_measure_number = int(focus_measure_number) if focus_measure_number is not None else None
-        except (TypeError, ValueError):
-            focus_measure_number = None
-        if focus_measure_number is not None and focus_measure_number < 1:
-            focus_measure_number = None
-
-        return {
-            "song_search_query": song_search_query,
-            "focus_measure_number": focus_measure_number,
-        }
-
-    def _build_theory_actions(self, scale: Optional[str], chord_choices: List[str]) -> list[dict]:
-        actions: list[dict] = []
-
-        for chord_name in chord_choices or []:
-            parsed = parse_chord_name(chord_name)
-            if not parsed:
-                continue
-            root, quality = parsed
-            actions.append(
-                {
-                    "type": "theory.show_chord",
-                    "root": root,
-                    "quality": quality,
-                }
-            )
-
-        if scale:
-            parsed_scale = parse_scale_name(scale)
-            if parsed_scale:
-                root, mode = parsed_scale
-                actions.append(
-                    {
-                        "type": "theory.show_scale",
-                        "root": root,
-                        "mode": mode,
-                    }
-                )
-
-        return actions
-
-    @staticmethod
     def _dedupe_actions(actions: list[dict]) -> list[dict]:
         deduped: list[dict] = []
         seen: set[str] = set()
@@ -603,182 +329,6 @@ class GuitarTutorAgent:
             seen.add(signature)
             deduped.append(action)
         return deduped
-
-    def _execute_song_actions(
-        self,
-        question_text: str,
-        ui_context: dict,
-        *,
-        song_search_query: str | None = None,
-        focus_measure_number: int | None = None,
-    ) -> tuple[str, list[dict]]:
-        """Run bounded Songsterr lookups for song/measure intents and return context + actions."""
-        if not self.tool_calling_enabled:
-            return "", []
-
-        lower_q = question_text.strip().lower()
-        search_query = song_search_query.strip() if isinstance(song_search_query, str) else None
-        if search_query and search_query.lower() in {"null", "none"}:
-            search_query = None
-
-        tool_context_lines: list[str] = []
-        actions: list[dict] = []
-
-        selected_song = (ui_context or {}).get("selected_song") or {}
-        selected_song_id = selected_song.get("song_id")
-        selected_track_index = int((ui_context or {}).get("selected_track_index") or 0)
-
-        # 1) Song search
-        if search_query:
-            ctx, acts, new_song_id, new_track = execute_song_search(search_query)
-            tool_context_lines.extend(ctx)
-            actions.extend(acts)
-            if new_song_id is not None:
-                selected_song_id = new_song_id
-                selected_track_index = new_track
-
-        # 2) Measure focus
-        focus_measure_index = focus_measure_number - 1 if isinstance(focus_measure_number, int) else None
-
-        # For deictic identification questions, trust UI beat context instead.
-        if self._is_context_identification_question(lower_q):
-            selected_beat = (ui_context or {}).get("selected_beat_id")
-            highlighted = (ui_context or {}).get("highlighted_notes") or []
-            if selected_beat:
-                tool_context_lines.append(
-                    f"User selected beat context: beat_id={selected_beat}, highlighted_frets={highlighted}."
-                )
-            focus_measure_index = None
-
-        if focus_measure_index is not None and selected_song_id is not None:
-            ctx, acts = resolve_measure_focus(
-                song_id=int(selected_song_id),
-                track_index=selected_track_index,
-                focus_measure_index=focus_measure_index,
-            )
-            tool_context_lines.extend(ctx)
-            actions.extend(acts)
-        elif focus_measure_index is not None:
-            tool_context_lines.append(
-                f"User asked to focus measure {focus_measure_number}, but no song is currently selected."
-            )
-
-        return "\n".join(tool_context_lines), self._dedupe_actions(actions)
-
-    @staticmethod
-    def _project_ui_context_for_prompt(ui_context: dict) -> dict:
-        """Pass only high-signal UI fields to prompts to reduce noise/token load."""
-        if not ui_context:
-            return {}
-
-        allowed_keys = [
-            "app_mode",
-            "display_mode",
-            "selected_tuning",
-            "selected_scale",
-            "selected_chord",
-            "selected_song",
-            "selected_track_index",
-            "song_view_mode",
-            "playhead_measure_index",
-            "selected_beat_id",
-            "highlighted_notes",
-        ]
-        projected: dict[str, Any] = {}
-        for key in allowed_keys:
-            if key in ui_context:
-                projected[key] = ui_context.get(key)
-
-        # Resolve highlighted fret positions to actual note names so the LLM
-        # doesn't have to do fret arithmetic (which it gets wrong).
-        highlighted = projected.get("highlighted_notes")
-        if highlighted and isinstance(highlighted, list):
-            tuning_id = ui_context.get("selected_tuning") or "standard"
-            custom_notes = ui_context.get("custom_tuning_notes")
-            tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
-
-            resolved = []
-            for hn in highlighted:
-                string_num = hn.get("string")
-                fret = hn.get("fret")
-                if string_num is None or fret is None:
-                    continue
-                # tuning_notes is indexed 0=string1, so string_num-1
-                idx = int(string_num) - 1
-                if 0 <= idx < len(tuning_notes):
-                    note = get_note_at_fret(tuning_notes[idx], int(fret))
-                    resolved.append({**hn, "note": note})
-                else:
-                    resolved.append(hn)
-            projected["highlighted_notes"] = resolved
-
-        return projected
-
-    @staticmethod
-    def _is_context_identification_question(lower_question: str) -> bool:
-        return any(
-            phrase in lower_question
-            for phrase in [
-                "what chord is this",
-                "which chord is this",
-                "what is this chord",
-                "identify this chord",
-                "name this chord",
-            ]
-        )
-
-    @staticmethod
-    def _has_strong_ui_context(ui_context: dict) -> bool:
-        if not ui_context:
-            return False
-        highlighted = ui_context.get("highlighted_notes") or []
-        has_highlighted = isinstance(highlighted, list) and len(highlighted) >= 2
-        has_selected_beat = bool(ui_context.get("selected_beat_id"))
-        has_song_or_playhead = bool(ui_context.get("selected_song")) or (
-            ui_context.get("playhead_measure_index") is not None
-        )
-        return (has_selected_beat or has_song_or_playhead) and has_highlighted
-
-    def _maybe_refresh_summary(self, state: dict) -> tuple[str, int]:
-        """Maintain a rolling summary for long threads (logical compaction)."""
-        running_summary = state.get("running_summary", "") or ""
-        summary_turn_count = int(state.get("summary_turn_count", 0) or 0)
-
-        if not self.summary_enabled:
-            return running_summary, summary_turn_count
-
-        messages = state.get("messages", [])
-        if not messages:
-            return running_summary, summary_turn_count
-
-        user_turns = sum(1 for m in messages if isinstance(m, HumanMessage))
-        if user_turns <= 0:
-            return running_summary, summary_turn_count
-
-        message_text = "\n".join(self._message_text(m) for m in messages)
-        threshold_hit = len(message_text) >= self.summary_char_threshold
-        interval_hit = user_turns % self.summary_turn_interval == 0 and user_turns != summary_turn_count
-
-        if not (threshold_hit or interval_hit):
-            return running_summary, summary_turn_count
-
-        keep_count = self.recent_turn_window * 2
-        older_messages = messages[:-keep_count] if len(messages) > keep_count else []
-        if not older_messages:
-            return running_summary, summary_turn_count
-
-        older_text = self._format_messages_for_prompt(older_messages)
-        summary_prompt = SUMMARY_INSTRUCTIONS.format(
-            running_summary=running_summary or "None",
-            older_messages=older_text,
-        )
-        try:
-            summary = self.llm.invoke([SystemMessage(content=summary_prompt)]).content
-            new_summary = self._coerce_text(summary).strip()
-            return new_summary, user_turns
-        except Exception as exc:
-            logger.warning("Summary refresh failed: %s", exc)
-            return running_summary, summary_turn_count
 
     # --- Public API: synchronous ---
 

--- a/backend/app/agent/nodes.py
+++ b/backend/app/agent/nodes.py
@@ -138,6 +138,7 @@ def _validate_highlight_groups(groups: list) -> list[dict]:
 
 
 def _classify_input(self: "GuitarTutorAgent", state: dict) -> dict:
+    """Node 1: Decide whether to answer, ask for clarification, or reject as out-of-scope."""
     messages = state.get("messages", [])
     ui_context = state.get("ui_context") or {}
     prompt_ui_context = _project_ui_context_for_prompt(ui_context)
@@ -149,7 +150,8 @@ def _classify_input(self: "GuitarTutorAgent", state: dict) -> dict:
     last_question_text = self._message_text(messages[-1]) if messages else ""
     lower_question = last_question_text.lower().strip()
 
-    # Deterministic fast-path: deictic chord-identification with strong UI context
+    # Fast-path: skip LLM classification for "what chord is this?" when the UI
+    # already provides highlighted notes — no ambiguity to resolve.
     if _is_context_identification_question(lower_question) and _has_strong_ui_context(ui_context):
         return {
             "clarifying_question_for_user": None,
@@ -175,6 +177,7 @@ def _classify_input(self: "GuitarTutorAgent", state: dict) -> dict:
 
     logger.info("Prepared question=%s", q)
 
+    # Some models return the literal string "null" instead of omitting the field.
     clarifying_question_for_user = q.get("clarifying_question_for_user")
     if isinstance(clarifying_question_for_user, str) and clarifying_question_for_user.strip().lower() in {"null", "none"}:
         clarifying_question_for_user = None
@@ -188,11 +191,14 @@ def _classify_input(self: "GuitarTutorAgent", state: dict) -> dict:
 
 
 def _clarify_input(self: "GuitarTutorAgent", state: dict) -> Command:
+    """Node 2: If classify_input set a clarifying question, pause the graph
+    with a LangGraph interrupt and wait for the user's response."""
     clarifying_question_for_user = state.get("clarifying_question_for_user")
 
     if not clarifying_question_for_user:
         return Command(goto="generate_answer")
 
+    # interrupt() pauses graph execution; the client calls resume_chat() to continue.
     human_input = interrupt(
         {
             "clarifying_question": clarifying_question_for_user,
@@ -211,6 +217,10 @@ def _clarify_input(self: "GuitarTutorAgent", state: dict) -> Command:
 
 
 def _generate_answer(self: "GuitarTutorAgent", state: dict) -> dict:
+    """Node 3: Produce the final response. Makes two LLM calls:
+    1. Generate natural-language answer text
+    2. Post-process to extract structured metadata (scale, chords, fretboard highlights)
+    Also runs song tool actions (search, measure focus) if the LLM planner requested them."""
     clarifying_question_for_user = state.get("clarifying_question_for_user")
     out_of_scope = state.get("out_of_scope", False)
     running_summary = state.get("running_summary", "")
@@ -356,6 +366,8 @@ def _plan_song_intent(
         fallback={"song_search_query": None, "focus_measure_number": None},
     )
 
+    # Sanitize model output — models sometimes return "null"/"none" strings
+    # or non-integer measure numbers that need coercion.
     song_search_query = plan.get("song_search_query")
     if isinstance(song_search_query, str):
         song_search_query = song_search_query.strip()
@@ -472,7 +484,16 @@ def _execute_song_actions(
 
 
 def _update_running_summary(self: "GuitarTutorAgent", state: dict) -> tuple[str, int]:
-    """Maintain a rolling summary for long threads (logical compaction)."""
+    """Conditionally regenerate the rolling conversation summary.
+
+    Long threads accumulate tokens fast. This compacts older messages into a
+    short summary that gets injected into prompts, keeping context window usage
+    bounded while preserving conversational coherence.
+
+    Triggers when either:
+    - Total message text exceeds summary_char_threshold
+    - User turn count hits the summary_turn_interval
+    """
     running_summary = state.get("running_summary", "") or ""
     summary_turn_count = int(state.get("summary_turn_count", 0) or 0)
 
@@ -494,6 +515,8 @@ def _update_running_summary(self: "GuitarTutorAgent", state: dict) -> tuple[str,
     if not (threshold_hit or interval_hit):
         return running_summary, summary_turn_count
 
+    # Only summarize messages outside the recent window — recent ones are
+    # passed directly to prompts for full fidelity.
     keep_count = self.recent_turn_window * 2
     older_messages = messages[:-keep_count] if len(messages) > keep_count else []
     if not older_messages:

--- a/backend/app/agent/nodes.py
+++ b/backend/app/agent/nodes.py
@@ -1,0 +1,513 @@
+"""
+Graph node functions for the Guitar Tutor LangGraph agent.
+
+Nodes:
+1. classify_input - classifies whether to proceed, clarify, or reject the user's question
+2. clarify_input - handles interrupt/resume for clarifying questions
+3. generate_answer - generates answer text + structured metadata/actions
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langgraph.types import Command, interrupt
+
+from app.agent.parser import parse_chord_name, parse_scale_name
+from app.agent.prompts import (
+    ANSWER_POSTPROCESS_INSTRUCTIONS,
+    ANSWER_TEXT_INSTRUCTIONS,
+    CLASSIFY_INPUT_INSTRUCTIONS,
+    SONG_TOOL_INTENT_INSTRUCTIONS,
+    SUMMARY_INSTRUCTIONS,
+)
+from app.agent.schemas import (
+    AnswerPostProcessSchema,
+    ClassificationSchema,
+    SongToolPlanSchema,
+)
+from app.agent.song_tools import execute_song_search, resolve_measure_focus
+from app.music.notes import get_note_at_fret
+from app.music.tunings import get_tuning_notes
+
+if TYPE_CHECKING:
+    from app.agent.agent import GuitarTutorAgent
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no agent state needed)
+# ---------------------------------------------------------------------------
+
+
+def _is_context_identification_question(lower_question: str) -> bool:
+    return any(
+        phrase in lower_question
+        for phrase in [
+            "what chord is this",
+            "which chord is this",
+            "what is this chord",
+            "identify this chord",
+            "name this chord",
+        ]
+    )
+
+
+def _has_strong_ui_context(ui_context: dict) -> bool:
+    if not ui_context:
+        return False
+    highlighted = ui_context.get("highlighted_notes") or []
+    has_highlighted = isinstance(highlighted, list) and len(highlighted) >= 2
+    has_selected_beat = bool(ui_context.get("selected_beat_id"))
+    has_song_or_playhead = bool(ui_context.get("selected_song")) or (
+        ui_context.get("playhead_measure_index") is not None
+    )
+    return (has_selected_beat or has_song_or_playhead) and has_highlighted
+
+
+def _project_ui_context_for_prompt(ui_context: dict) -> dict:
+    """Pass only high-signal UI fields to prompts to reduce noise/token load."""
+    if not ui_context:
+        return {}
+
+    allowed_keys = [
+        "app_mode",
+        "display_mode",
+        "selected_tuning",
+        "selected_scale",
+        "selected_chord",
+        "selected_song",
+        "selected_track_index",
+        "song_view_mode",
+        "playhead_measure_index",
+        "selected_beat_id",
+        "highlighted_notes",
+    ]
+    projected: dict[str, Any] = {}
+    for key in allowed_keys:
+        if key in ui_context:
+            projected[key] = ui_context.get(key)
+
+    # Resolve highlighted fret positions to actual note names so the LLM
+    # doesn't have to do fret arithmetic (which it gets wrong).
+    highlighted = projected.get("highlighted_notes")
+    if highlighted and isinstance(highlighted, list):
+        tuning_id = ui_context.get("selected_tuning") or "standard"
+        custom_notes = ui_context.get("custom_tuning_notes")
+        tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
+
+        resolved = []
+        for hn in highlighted:
+            string_num = hn.get("string")
+            fret = hn.get("fret")
+            if string_num is None or fret is None:
+                continue
+            # tuning_notes is indexed 0=string1, so string_num-1
+            idx = int(string_num) - 1
+            if 0 <= idx < len(tuning_notes):
+                note = get_note_at_fret(tuning_notes[idx], int(fret))
+                resolved.append({**hn, "note": note})
+            else:
+                resolved.append(hn)
+        projected["highlighted_notes"] = resolved
+
+    return projected
+
+
+def _validate_highlight_groups(groups: list) -> list[dict]:
+    """Validate and filter highlight groups from structured output."""
+    valid_groups = []
+    for g in (groups or []):
+        name = g.get("name", "").strip()
+        positions = [
+            p for p in (g.get("positions") or [])
+            if isinstance(p.get("string"), int) and isinstance(p.get("fret"), int)
+            and 1 <= p["string"] <= 6 and 0 <= p["fret"] <= 22
+        ]
+        if name and positions:
+            valid_groups.append({"name": name, "positions": positions})
+    return valid_groups
+
+
+# ---------------------------------------------------------------------------
+# Graph nodes (take `self` — assigned as methods on GuitarTutorAgent)
+# ---------------------------------------------------------------------------
+
+
+def _classify_input(self: "GuitarTutorAgent", state: dict) -> dict:
+    messages = state.get("messages", [])
+    ui_context = state.get("ui_context") or {}
+    prompt_ui_context = _project_ui_context_for_prompt(ui_context)
+
+    running_summary, summary_turn_count = self._update_running_summary(state)
+
+    recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
+    previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
+    last_question_text = self._message_text(messages[-1]) if messages else ""
+    lower_question = last_question_text.lower().strip()
+
+    # Deterministic fast-path: deictic chord-identification with strong UI context
+    if _is_context_identification_question(lower_question) and _has_strong_ui_context(ui_context):
+        return {
+            "clarifying_question_for_user": None,
+            "out_of_scope": False,
+            "running_summary": running_summary,
+            "summary_turn_count": summary_turn_count,
+        }
+
+    system_message = SystemMessage(
+        content=CLASSIFY_INPUT_INSTRUCTIONS.format(
+            running_summary=running_summary or "None",
+            previous_context=previous_context,
+            ui_context=prompt_ui_context or "None",
+            user_question=last_question_text,
+        )
+    )
+
+    q = self._invoke_structured(
+        ClassificationSchema,
+        [system_message],
+        fallback={"out_of_scope": False},
+    )
+
+    logger.info("Prepared question=%s", q)
+
+    clarifying_question_for_user = q.get("clarifying_question_for_user")
+    if isinstance(clarifying_question_for_user, str) and clarifying_question_for_user.strip().lower() in {"null", "none"}:
+        clarifying_question_for_user = None
+
+    return {
+        "clarifying_question_for_user": clarifying_question_for_user,
+        "out_of_scope": q.get("out_of_scope", False),
+        "running_summary": running_summary,
+        "summary_turn_count": summary_turn_count,
+    }
+
+
+def _clarify_input(self: "GuitarTutorAgent", state: dict) -> Command:
+    clarifying_question_for_user = state.get("clarifying_question_for_user")
+
+    if not clarifying_question_for_user:
+        return Command(goto="generate_answer")
+
+    human_input = interrupt(
+        {
+            "clarifying_question": clarifying_question_for_user,
+            "action": "Please answer this question to continue",
+        }
+    )
+
+    return Command(
+        update={
+            "messages": [HumanMessage(content=human_input.get("response", ""))],
+            "clarifying_question_for_user": None,
+            "out_of_scope": False,
+        },
+        goto="generate_answer",
+    )
+
+
+def _generate_answer(self: "GuitarTutorAgent", state: dict) -> dict:
+    clarifying_question_for_user = state.get("clarifying_question_for_user")
+    out_of_scope = state.get("out_of_scope", False)
+    running_summary = state.get("running_summary", "")
+    ui_context = state.get("ui_context") or {}
+    memory_status = state.get("memory_status", "fresh")
+
+    if out_of_scope:
+        refusal_msg = (
+            "I only help with guitar, songs/tabs, measures, and music theory. "
+            "Ask about chords, scales, fretboard shapes, progressions, songs, or tab sections."
+        )
+        return {
+            "messages": [AIMessage(content=refusal_msg)],
+            "answer": refusal_msg,
+            "scale": None,
+            "chord_choices": [],
+            "visualizations": False,
+            "out_of_scope": True,
+            "actions": [],
+            "memory_status": memory_status,
+        }
+
+    if clarifying_question_for_user:
+        return {
+            "messages": [AIMessage(content=clarifying_question_for_user)],
+            "answer": clarifying_question_for_user,
+            "scale": None,
+            "chord_choices": [],
+            "visualizations": False,
+            "out_of_scope": False,
+            "actions": [],
+            "memory_status": memory_status,
+        }
+
+    messages = state.get("messages", [])
+    user_question = self._message_text(messages[-1]) if messages else ""
+    prompt_ui_context = _project_ui_context_for_prompt(ui_context)
+    song_tool_plan = _plan_song_intent(
+        self,
+        user_question=user_question,
+        messages=messages,
+        ui_context=ui_context,
+        running_summary=running_summary,
+    )
+    logger.info("Song tool plan=%s", song_tool_plan)
+    tool_context, song_actions = _execute_song_actions(
+        self,
+        user_question,
+        ui_context,
+        song_search_query=song_tool_plan.get("song_search_query"),
+        focus_measure_number=song_tool_plan.get("focus_measure_number"),
+    )
+
+    # Call 1: Generate answer text (regular LLM — streamed via stream_mode="messages")
+    text_system = SystemMessage(
+        content=ANSWER_TEXT_INSTRUCTIONS.format(
+            running_summary=running_summary or "None",
+            ui_context=prompt_ui_context or "None",
+            tool_context=tool_context or "None",
+        )
+    )
+
+    # Include recent conversation history so the LLM can resolve
+    # follow-up references ("this", "those chords", "show me visualizations for that")
+    recent_history = messages[-(self.recent_turn_window * 2):]
+    llm_messages = [text_system] + recent_history
+    response = self.llm.invoke(llm_messages)
+    answer_text = self._clean_answer_text(self._coerce_text(response.content))
+
+    # Call 2: Extract metadata + fretboard highlights in one structured call
+    tuning_id = ui_context.get("selected_tuning") or "standard"
+    custom_notes = ui_context.get("custom_tuning_notes")
+    tuning_notes = custom_notes if custom_notes else get_tuning_notes(tuning_id)
+
+    postprocess_system = SystemMessage(
+        content=ANSWER_POSTPROCESS_INSTRUCTIONS.format(
+            user_question=user_question,
+            answer=answer_text,
+            ui_context=prompt_ui_context or "None",
+            tuning_notes=tuning_notes,
+        )
+    )
+    post = self._invoke_structured(
+        AnswerPostProcessSchema,
+        [postprocess_system],
+        fallback={"scale": None, "chord_choices": [], "visualizations": False, "highlight_groups": []},
+    )
+
+    actions: list[dict] = []
+    if self.actions_enabled:
+        actions.extend(song_actions)
+        actions.extend(_build_theory_actions(post.get("scale"), post.get("chord_choices", [])))
+
+        # Validate and add highlight groups from the combined call
+        highlight_groups = _validate_highlight_groups(post.get("highlight_groups", []))
+        if highlight_groups:
+            actions.append({"type": "fretboard.highlight", "groups": highlight_groups})
+
+        actions = self._dedupe_actions(actions)
+
+    return {
+        "messages": [AIMessage(content=answer_text)],
+        "answer": answer_text,
+        "scale": post.get("scale"),
+        "chord_choices": post.get("chord_choices", []),
+        "visualizations": post.get("visualizations", False),
+        "out_of_scope": False,
+        "actions": actions,
+        "memory_status": memory_status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Node helpers (take `self` — assigned as methods on GuitarTutorAgent)
+# ---------------------------------------------------------------------------
+
+
+def _plan_song_intent(
+    self: "GuitarTutorAgent",
+    *,
+    user_question: str,
+    messages: list,
+    ui_context: dict,
+    running_summary: str,
+) -> dict:
+    """Use the answer-phase model to decide if song tools are needed."""
+    prompt_ui_context = _project_ui_context_for_prompt(ui_context)
+    recent_messages = messages[-(self.recent_turn_window * 2):] if messages else []
+    previous_context = self._format_messages_for_prompt(recent_messages[:-1]) if len(recent_messages) > 1 else "None"
+
+    system_message = SystemMessage(
+        content=SONG_TOOL_INTENT_INSTRUCTIONS.format(
+            running_summary=running_summary or "None",
+            previous_context=previous_context,
+            ui_context=prompt_ui_context or "None",
+            user_question=user_question,
+        )
+    )
+
+    plan = self._invoke_structured(
+        SongToolPlanSchema,
+        [system_message],
+        fallback={"song_search_query": None, "focus_measure_number": None},
+    )
+
+    song_search_query = plan.get("song_search_query")
+    if isinstance(song_search_query, str):
+        song_search_query = song_search_query.strip()
+        if song_search_query.lower() in {"", "null", "none"}:
+            song_search_query = None
+    else:
+        song_search_query = None
+
+    focus_measure_number = plan.get("focus_measure_number")
+    try:
+        focus_measure_number = int(focus_measure_number) if focus_measure_number is not None else None
+    except (TypeError, ValueError):
+        focus_measure_number = None
+    if focus_measure_number is not None and focus_measure_number < 1:
+        focus_measure_number = None
+
+    return {
+        "song_search_query": song_search_query,
+        "focus_measure_number": focus_measure_number,
+    }
+
+
+def _build_theory_actions(scale: Optional[str], chord_choices: List[str]) -> list[dict]:
+    actions: list[dict] = []
+
+    for chord_name in chord_choices or []:
+        parsed = parse_chord_name(chord_name)
+        if not parsed:
+            continue
+        root, quality = parsed
+        actions.append(
+            {
+                "type": "theory.show_chord",
+                "root": root,
+                "quality": quality,
+            }
+        )
+
+    if scale:
+        parsed_scale = parse_scale_name(scale)
+        if parsed_scale:
+            root, mode = parsed_scale
+            actions.append(
+                {
+                    "type": "theory.show_scale",
+                    "root": root,
+                    "mode": mode,
+                }
+            )
+
+    return actions
+
+
+def _execute_song_actions(
+    self: "GuitarTutorAgent",
+    question_text: str,
+    ui_context: dict,
+    *,
+    song_search_query: str | None = None,
+    focus_measure_number: int | None = None,
+) -> tuple[str, list[dict]]:
+    """Run bounded Songsterr lookups for song/measure intents and return context + actions."""
+    if not self.tool_calling_enabled:
+        return "", []
+
+    lower_q = question_text.strip().lower()
+    search_query = song_search_query.strip() if isinstance(song_search_query, str) else None
+    if search_query and search_query.lower() in {"null", "none"}:
+        search_query = None
+
+    tool_context_lines: list[str] = []
+    actions: list[dict] = []
+
+    selected_song = (ui_context or {}).get("selected_song") or {}
+    selected_song_id = selected_song.get("song_id")
+    selected_track_index = int((ui_context or {}).get("selected_track_index") or 0)
+
+    # 1) Song search
+    if search_query:
+        ctx, acts, new_song_id, new_track = execute_song_search(search_query)
+        tool_context_lines.extend(ctx)
+        actions.extend(acts)
+        if new_song_id is not None:
+            selected_song_id = new_song_id
+            selected_track_index = new_track
+
+    # 2) Measure focus
+    focus_measure_index = focus_measure_number - 1 if isinstance(focus_measure_number, int) else None
+
+    # For deictic identification questions, trust UI beat context instead.
+    if _is_context_identification_question(lower_q):
+        selected_beat = (ui_context or {}).get("selected_beat_id")
+        highlighted = (ui_context or {}).get("highlighted_notes") or []
+        if selected_beat:
+            tool_context_lines.append(
+                f"User selected beat context: beat_id={selected_beat}, highlighted_frets={highlighted}."
+            )
+        focus_measure_index = None
+
+    if focus_measure_index is not None and selected_song_id is not None:
+        ctx, acts = resolve_measure_focus(
+            song_id=int(selected_song_id),
+            track_index=selected_track_index,
+            focus_measure_index=focus_measure_index,
+        )
+        tool_context_lines.extend(ctx)
+        actions.extend(acts)
+    elif focus_measure_index is not None:
+        tool_context_lines.append(
+            f"User asked to focus measure {focus_measure_number}, but no song is currently selected."
+        )
+
+    return "\n".join(tool_context_lines), self._dedupe_actions(actions)
+
+
+def _update_running_summary(self: "GuitarTutorAgent", state: dict) -> tuple[str, int]:
+    """Maintain a rolling summary for long threads (logical compaction)."""
+    running_summary = state.get("running_summary", "") or ""
+    summary_turn_count = int(state.get("summary_turn_count", 0) or 0)
+
+    if not self.summary_enabled:
+        return running_summary, summary_turn_count
+
+    messages = state.get("messages", [])
+    if not messages:
+        return running_summary, summary_turn_count
+
+    user_turns = sum(1 for m in messages if isinstance(m, HumanMessage))
+    if user_turns <= 0:
+        return running_summary, summary_turn_count
+
+    message_text = "\n".join(self._message_text(m) for m in messages)
+    threshold_hit = len(message_text) >= self.summary_char_threshold
+    interval_hit = user_turns % self.summary_turn_interval == 0 and user_turns != summary_turn_count
+
+    if not (threshold_hit or interval_hit):
+        return running_summary, summary_turn_count
+
+    keep_count = self.recent_turn_window * 2
+    older_messages = messages[:-keep_count] if len(messages) > keep_count else []
+    if not older_messages:
+        return running_summary, summary_turn_count
+
+    older_text = self._format_messages_for_prompt(older_messages)
+    summary_prompt = SUMMARY_INSTRUCTIONS.format(
+        running_summary=running_summary or "None",
+        older_messages=older_text,
+    )
+    try:
+        summary = self.llm.invoke([SystemMessage(content=summary_prompt)]).content
+        new_summary = self._coerce_text(summary).strip()
+        return new_summary, user_turns
+    except Exception as exc:
+        logger.warning("Summary refresh failed: %s", exc)
+        return running_summary, summary_turn_count

--- a/backend/app/agent/prompts.py
+++ b/backend/app/agent/prompts.py
@@ -1,0 +1,125 @@
+"""Prompt templates for the Guitar Tutor agent."""
+
+CLASSIFY_INPUT_INSTRUCTIONS = """You are the Guitar Tutor gate. Decide whether to proceed, clarify, or reject the user's question. Do NOT answer the question yourself.
+
+Inputs:
+- running_summary: {running_summary}
+- previous_context: {previous_context}
+- ui_context: {ui_context}
+- user_question: {user_question}
+
+Return JSON ONLY. Produce exactly one of these shapes:
+1) Proceed (preferred)
+{{"out_of_scope": false}}
+
+2) Need clarification
+{{"clarifying_question_for_user": "<one short clarifying question>", "out_of_scope": false}}
+
+3) Out of scope
+{{"out_of_scope": true}}
+
+Guidelines:
+- Default to proceeding. Trust the answer model's judgement to handle ambiguity, fill in gaps, and make creative choices.
+- Never clarify about format, notation style, or level of detail — just proceed.
+- Never clarify to confirm intent — if the user mentions a song, artist, chord, scale, or technique, proceed.
+- Only clarify when the question is genuinely unanswerable without more info (e.g. "help me with this" with zero context).
+- For a pure greeting with no music content, use clarifying_question_for_user to greet briefly and ask what guitar/music help they want.
+- If the request is not about music, guitar, songs, tabs, measures, or music theory, return out_of_scope true.
+"""
+
+SONG_TOOL_INTENT_INSTRUCTIONS = """You are deciding whether the Guitar Tutor should use song UI tools before answering. Do NOT answer the user.
+
+Inputs:
+- running_summary: {running_summary}
+- previous_context: {previous_context}
+- ui_context: {ui_context}
+- user_question: {user_question}
+
+Return JSON ONLY with this exact shape:
+{{
+  "song_search_query": string | null,
+  "focus_measure_number": integer | null
+}}
+
+Rules:
+- Use "song_search_query" when the user wants to open, load, search, show, display, or learn a specific song/tab in the Songs UI.
+- Natural teaching phrasing still counts as song intent. Example: "show me how to play wonderwall" should return {{"song_search_query": "wonderwall", "focus_measure_number": null}}.
+- Include artist names when they are present or clearly implied. Example: "teach me frisky by dominic fike" -> "frisky dominic fike".
+- Do NOT set song_search_query for theory-only requests like chords, scales, intervals, fretboard notes, or generic techniques.
+- Use "focus_measure_number" only when the user explicitly asks to jump to, show, start at, or focus a numbered measure in a song.
+- Measure numbers are 1-based in your output.
+- If no song tool is needed, return null for both fields.
+"""
+
+ANSWER_TEXT_INSTRUCTIONS = """You are the Guitar Tutor. Answer the user's guitar/music theory question.
+
+Hard constraints:
+- ONLY answer music theory, guitar, songs, tabs, and measure-navigation related questions.
+- Keep output concise: 1-3 paragraphs.
+
+Inputs:
+- Running summary: {running_summary}
+- UI context: {ui_context}
+- Tool context: {tool_context}
+
+Behavior:
+- Be clear and pedagogical. Explain WHY choices work.
+- The user's explicit intent always takes priority over the current UI state.
+- Use ui_context for current selection/playhead/highlighted notes only when the user references "this"/"current" context.
+- If a song/tool lookup succeeded, ground your answer in those results.
+- Do NOT say you lack direct tab database access. You are integrated with a song-tab lookup tool.
+"""
+
+ANSWER_POSTPROCESS_INSTRUCTIONS = """Given a guitar/music question and answer, extract structured metadata AND fretboard highlight positions in a single response.
+
+Question: {user_question}
+Answer: {answer}
+UI context: {ui_context}
+Tuning (string 1=high E to string 6=low E): {tuning_notes}
+
+--- PART 1: Metadata ---
+Extract:
+- scale: the single most relevant scale name (e.g., "A minor pentatonic"), or null
+- chord_choices: list of chord names mentioned or recommended (e.g., ["C", "Am", "F", "G"])
+- visualizations: true if the answer involves chords, scales, progressions, song tabs, or measure navigation
+
+--- PART 2: Fretboard highlights ---
+Extract highlight_groups: fret positions to highlight on the interactive fretboard.
+
+When to emit groups:
+- Emit groups when the answer discusses SPECIFIC fret positions, voicings, shapes, or fingerings. This includes:
+  - Explicit string/fret references (e.g. "3rd fret on the A string")
+  - Tab-notation voicings (e.g. "x32010", "3x2003") — convert these to string/fret positions (leftmost digit = string 6/low E, rightmost = string 1/high E; "x" = muted/skip, "0" = open)
+  - Named shapes with positions (e.g. "CAGED shape at fret 5", "barre chord at 7th fret")
+- Do NOT emit groups for general theory, chord names without ANY position info, or scale names without specific fret references.
+
+Group rules:
+- Each group is one named shape/voicing/position set. Multiple groups = multiple alternatives to cycle through.
+- String numbering: string 1 = high E (thinnest), string 6 = low E (thickest). Fret 0 = open string.
+- Keep group names short (2-5 words), e.g. "Open E", "Barre at 5th", "Box 1", "CAGED A shape".
+- Omit muted/unplayed strings — only include strings that are actually fretted or open and part of the shape.
+- Max 6 groups. Max 6 positions per group.
+
+Playability constraints (CRITICAL — every voicing MUST be physically playable):
+- Max 4-fret span between the lowest and highest fretted notes (excluding open strings). Stretch up to 5 frets ONLY for intentionally creative/extended voicings.
+- At most one note per string.
+- All fretted notes must be reachable simultaneously by a human fretting hand — no impossible finger stretches.
+- Prefer standard voicing positions (open chords, common barre shapes, CAGED forms) unless the user specifically asks for unusual or creative voicings.
+- When suggesting chord progressions, use voicings in nearby positions to minimize hand movement between chords.
+
+Return empty list if no specific fret positions apply.
+"""
+
+SUMMARY_INSTRUCTIONS = """Summarize the conversation for future guitar tutoring context.
+
+Current running summary:
+{running_summary}
+
+Older raw messages to compress:
+{older_messages}
+
+Return a concise summary under 180 words capturing:
+- User goals/preferences
+- Musical key/tuning/song context
+- Prior recommendations and constraints
+"""

--- a/backend/app/agent/schemas.py
+++ b/backend/app/agent/schemas.py
@@ -1,0 +1,71 @@
+"""Schemas and state definitions for the Guitar Tutor agent."""
+
+from typing import List, Optional, TypedDict
+
+from langgraph.graph import MessagesState
+from pydantic import BaseModel, Field
+
+
+class ClassificationSchema(TypedDict):
+    """Schema for the classify_input node output."""
+
+    out_of_scope: bool = Field(False, description="Whether the question is out of scope")
+    clarifying_question_for_user: Optional[str] = Field(None, description="A clarifying question to send to the user")
+
+
+class SongToolPlanSchema(BaseModel):
+    """Structured song-tool intent chosen during answer generation."""
+
+    song_search_query: Optional[str] = Field(
+        None,
+        description=(
+            "Search query for a specific song the user wants opened in the song UI, "
+            "for example 'frisky dominic fike'. Null when no song lookup is needed."
+        ),
+    )
+    focus_measure_number: Optional[int] = Field(
+        None,
+        description=(
+            "1-based measure number the user wants focused in the currently selected or requested song. "
+            "Null when no measure navigation is needed."
+        ),
+    )
+
+
+class FretboardHighlightPositionSchema(TypedDict):
+    string: int
+    fret: int
+
+
+class FretboardHighlightGroupSchema(TypedDict):
+    name: str
+    positions: List[FretboardHighlightPositionSchema]
+
+
+class AnswerPostProcessSchema(TypedDict):
+    """Combined schema for metadata extraction + fretboard highlights in one call."""
+
+    scale: Optional[str] = Field(None, description="Most relevant scale name")
+    chord_choices: List[str] = Field(default_factory=list, description="List of chord names recommended")
+    visualizations: bool = Field(False, description="Whether visualizations are needed")
+    highlight_groups: List[FretboardHighlightGroupSchema] = Field(default_factory=list, description="Fretboard highlight groups")
+
+
+class OverallState(MessagesState):
+    """Overall state for the agent graph."""
+
+    clarifying_question_for_user: Optional[str] = None
+    answer: str = ""
+    scale: Optional[str] = None
+    chord_choices: List[str] = []
+    visualizations: bool = False
+    out_of_scope: bool = False
+
+    # Context/memory fields
+    ui_context: dict = {}
+    running_summary: str = ""
+    summary_turn_count: int = 0
+
+    # Response fields
+    actions: List[dict] = []
+    memory_status: str = "fresh"

--- a/backend/app/agent/song_tools.py
+++ b/backend/app/agent/song_tools.py
@@ -1,0 +1,148 @@
+"""Song search, matching, and measure-focus tools for the Guitar Tutor agent."""
+
+import logging
+import re
+from typing import Any, List, Optional
+
+from app.models.songsterr import SongsterrRecord
+from app.services import songsterr
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_search_text(text: str) -> str:
+    lowered = text.lower().strip()
+    lowered = re.sub(r"[^a-z0-9\s]", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered).strip()
+    return lowered
+
+
+def split_query_title_artist(query: str) -> tuple[str, str]:
+    cleaned = normalize_search_text(query)
+    if " by " in cleaned:
+        title, artist = cleaned.split(" by ", 1)
+        return title.strip(), artist.strip()
+    return cleaned, ""
+
+
+def score_song_match(record: SongsterrRecord, query: str) -> int:
+    query_norm = normalize_search_text(query)
+    title_norm = normalize_search_text(record.title)
+    artist_norm = normalize_search_text(record.artist)
+    combined = f"{title_norm} {artist_norm}".strip()
+    q_title, q_artist = split_query_title_artist(query)
+
+    score = 0
+
+    # Strong exact/near-exact signals first.
+    if query_norm == combined:
+        score += 120
+    if q_title and q_title == title_norm:
+        score += 90
+    if q_artist and q_artist == artist_norm:
+        score += 80
+    if q_title and title_norm.startswith(q_title):
+        score += 40
+    if q_artist and artist_norm.startswith(q_artist):
+        score += 35
+
+    # Token overlap fallback.
+    q_tokens = set(query_norm.split())
+    c_tokens = set(combined.split())
+    if q_tokens and c_tokens:
+        overlap = len(q_tokens & c_tokens)
+        score += overlap * 8
+        # Penalize extra unrelated tokens for close-title collisions.
+        score -= max(0, len(c_tokens - q_tokens)) * 2
+
+    # Small boost for exact title even if artist differs slightly.
+    if q_title and title_norm == q_title:
+        score += 15
+
+    return score
+
+
+def choose_best_song_match(
+    records: List[SongsterrRecord], query: str
+) -> tuple[Optional[SongsterrRecord], int]:
+    if not records:
+        return None, 0
+
+    scored = [(record, score_song_match(record, query)) for record in records[:25]]
+    scored.sort(key=lambda x: x[1], reverse=True)
+    best_record, best_score = scored[0]
+    return best_record, best_score
+
+
+def execute_song_search(search_query: str) -> tuple[list[str], list[dict], int | None, int]:
+    """Search Songsterr for a song and auto-select the best match.
+
+    Returns (context_lines, actions, selected_song_id, selected_track_index).
+    """
+    context_lines: list[str] = []
+    actions: list[dict] = []
+    selected_song_id: int | None = None
+    selected_track_index: int = 0
+
+    try:
+        records = songsterr.search_songs_sync(search_query)
+        if records:
+            actions.append({"type": "song.search", "query": search_query})
+            best, score = choose_best_song_match(records, search_query)
+            if best and score >= 55:
+                actions.append({"type": "song.select", "song_id": best.song_id})
+                actions.append({"type": "song.track.select", "track_index": 0})
+                selected_song_id = best.song_id
+                context_lines.append(
+                    f"Song search '{search_query}' matched: {best.artist} - {best.title} "
+                    f"(song_id={best.song_id}, score={score})."
+                )
+            else:
+                context_lines.append(
+                    f"Song search '{search_query}' returned results but no confident auto-select "
+                    f"(best score={score})."
+                )
+        else:
+            context_lines.append(f"Song search '{search_query}' returned no results.")
+    except Exception as exc:
+        context_lines.append(f"Song search failed for '{search_query}': {exc}")
+
+    return context_lines, actions, selected_song_id, selected_track_index
+
+
+def resolve_measure_focus(
+    song_id: int,
+    track_index: int,
+    focus_measure_index: int,
+) -> tuple[list[str], list[dict]]:
+    """Resolve a measure focus request into context lines and actions.
+
+    Returns (context_lines, actions).
+    """
+    context_lines: list[str] = []
+    actions: list[dict] = []
+
+    try:
+        resolved_measure, resolved_beat = songsterr.resolve_measure_focus_sync(
+            song_id=song_id,
+            track_index=track_index,
+            requested_measure_index=max(0, focus_measure_index),
+        )
+        action: dict[str, Any] = {
+            "type": "song.measure.focus",
+            "measure_index": resolved_measure,
+        }
+        if resolved_beat is not None:
+            action["beat_index"] = resolved_beat
+        actions.append(action)
+        context_lines.append(
+            f"Resolved measure focus for song_id={song_id}, track={track_index}: "
+            f"measure_index={resolved_measure}, beat_index={resolved_beat}."
+        )
+    except Exception as exc:
+        context_lines.append(
+            f"Could not resolve measure focus for song_id={song_id}, "
+            f"track={track_index}: {exc}"
+        )
+
+    return context_lines, actions

--- a/backend/tests/test_agent_song_tools.py
+++ b/backend/tests/test_agent_song_tools.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest.mock import patch
+
+from app.agent.agent import GuitarTutorAgent
+from app.models.songsterr import SongsterrRecord
+
+
+def _make_agent() -> GuitarTutorAgent:
+    agent = object.__new__(GuitarTutorAgent)
+    agent.tool_calling_enabled = True
+    agent.recent_turn_window = 10
+    return agent
+
+
+def _song_record(*, song_id: int, artist: str, title: str) -> SongsterrRecord:
+    return SongsterrRecord.model_validate(
+        {
+            "songId": song_id,
+            "artistId": 1,
+            "artist": artist,
+            "title": title,
+            "hasChords": True,
+            "hasPlayer": True,
+            "tracks": [],
+            "defaultTrack": 0,
+            "popularTrack": 0,
+        }
+    )
+
+
+class GuitarTutorAgentSongToolTests(unittest.TestCase):
+    def test_plan_song_intent_sanitizes_model_output(self) -> None:
+        agent = _make_agent()
+        agent._project_ui_context_for_prompt = lambda ui_context: ui_context
+        agent._format_messages_for_prompt = lambda messages: "None"
+        agent._invoke_structured = lambda schema, messages, fallback: {
+            "song_search_query": " wonderwall oasis ",
+            "focus_measure_number": "12",
+        }
+
+        plan = agent._plan_song_intent(
+            user_question="Show me how to play Wonderwall",
+            messages=[],
+            ui_context={},
+            running_summary="",
+        )
+
+        self.assertEqual(
+            plan,
+            {
+                "song_search_query": "wonderwall oasis",
+                "focus_measure_number": 12,
+            },
+        )
+
+    @patch("app.agent.song_tools.songsterr.search_songs_sync")
+    def test_execute_song_actions_does_not_fallback_to_regex_without_llm_plan(self, search_songs_sync) -> None:
+        agent = _make_agent()
+
+        tool_context, actions = agent._execute_song_actions(
+            "show me how to play wonderwall",
+            {},
+            song_search_query=None,
+            focus_measure_number=None,
+        )
+
+        search_songs_sync.assert_not_called()
+        self.assertEqual(tool_context, "")
+        self.assertEqual(actions, [])
+
+    @patch("app.agent.song_tools.songsterr.resolve_measure_focus_sync", return_value=(4, 1))
+    @patch("app.agent.song_tools.songsterr.search_songs_sync")
+    def test_execute_song_actions_executes_llm_selected_song_actions(self, search_songs_sync, resolve_measure_focus_sync) -> None:
+        agent = _make_agent()
+        search_songs_sync.return_value = [_song_record(song_id=7, artist="Oasis", title="Wonderwall")]
+
+        tool_context, actions = agent._execute_song_actions(
+            "show me how to play wonderwall",
+            {},
+            song_search_query="wonderwall oasis",
+            focus_measure_number=5,
+        )
+
+        search_songs_sync.assert_called_once_with("wonderwall oasis")
+        resolve_measure_focus_sync.assert_called_once_with(
+            song_id=7,
+            track_index=0,
+            requested_measure_index=4,
+        )
+        self.assertEqual(
+            actions,
+            [
+                {"type": "song.search", "query": "wonderwall oasis"},
+                {"type": "song.select", "song_id": 7},
+                {"type": "song.track.select", "track_index": 0},
+                {"type": "song.measure.focus", "measure_index": 4, "beat_index": 1},
+            ],
+        )
+        self.assertIn("Oasis - Wonderwall", tool_context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refactor: Extract agent modules for readability

Breaks the monolithic agent.py (800+ lines) into focused, single-responsibility modules while preserving all existing behavior.

Changes
schemas.py — Extracted Pydantic models and state definitions into their own module
prompts.py — Extracted all LLM prompt templates
song_tools.py — Extracted song search/navigation tool logic
nodes.py — Extracted the three graph node functions (classify_input, clarify_input, generate_answer) from the main agent file
agent.py — Now only contains the graph definition and wiring; imports everything else
Renamed prepare_question → classify_input to better describe what the gate node does
Updated tests to match renamed methods and new patch paths